### PR TITLE
✨ feat(Alliance Levers): new endpoint

### DIFF
--- a/clarisa-back/migrations/1729007797004-addAllianceLevers.ts
+++ b/clarisa-back/migrations/1729007797004-addAllianceLevers.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAllianceLevers1729007797004 implements MigrationInterface {
+  name = 'AddAllianceLevers1729007797004';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`levers\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`short_name\` text NULL, \`full_name\` text NULL, \`created_at\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`is_active\` tinyint(1) NOT NULL DEFAULT 1, \`created_by\` bigint NOT NULL, \`updated_by\` bigint NULL, \`modification_justification\` text NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `INSERT INTO \`levers\` (\`short_name\`, \`full_name\`, \`created_by\`) VALUES ('Lever 1', 'Lever 1: Food Environments and Consumer Behavior', 4372), ('Lever 2', 'Lever 2: Multifunctional Landscapes', 4372), ('Lever 3', 'Lever 3: Climate Action', 4372), ('Lever 4', 'Lever 4: Biodiversity for Food and Agriculture', 4372), ('Lever 5', 'Lever 5: Digital Inclusion', 4372), ('Lever 6', 'Lever 6: Crops for Nutrition and Health', 4372), ('Lever 7', 'Lever 7: Gender and Inclusion', 4372), ('Lever 8', 'Lever 8: Performance, Innovation and Strategic Analysis for Impact', 4372);`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE \`levers\``);
+  }
+}

--- a/clarisa-back/src/api/api.module.ts
+++ b/clarisa-back/src/api/api.module.ts
@@ -80,6 +80,7 @@ import { MicroserviceMonitoringTestLinkModule } from './microservice-monitoring-
 import { IntegrationModule } from '../integration/integration.module';
 import { GlobalParameterModule } from './global-parameter/global-parameter.module';
 import { HandlebarsTemplateModule } from './handlebars-template/handlebars-template.module';
+import { LeverModule } from './lever/lever.module';
 
 @Module({
   controllers: [ApiController],
@@ -162,6 +163,7 @@ import { HandlebarsTemplateModule } from './handlebars-template/handlebars-templ
     MicroserviceMonitoringTestLinkModule,
     GlobalParameterModule,
     HandlebarsTemplateModule,
+    LeverModule,
   ],
 })
 export class ApiModule {}

--- a/clarisa-back/src/api/api.routes.ts
+++ b/clarisa-back/src/api/api.routes.ts
@@ -74,6 +74,7 @@ import { AppSecretModule } from './app-secret/app-secret.module';
 import { MicroserviceMonitoringTestLinkModule } from './microservice-monitoring-test-link/microservice-monitoring-test-link.module';
 import { GlobalParameterModule } from './global-parameter/global-parameter.module';
 import { HandlebarsTemplateModule } from './handlebars-template/handlebars-template.module';
+import { LeverModule } from './lever/lever.module';
 
 export const apiRoutes = [
   {
@@ -379,5 +380,9 @@ export const apiRoutes = [
   {
     path: 'handlebars-templates',
     module: HandlebarsTemplateModule,
+  },
+  {
+    path: 'alliance-levers',
+    module: LeverModule,
   },
 ];

--- a/clarisa-back/src/api/lever/entities/lever.entity.ts
+++ b/clarisa-back/src/api/lever/entities/lever.entity.ts
@@ -1,0 +1,21 @@
+import { Exclude } from 'class-transformer';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { AuditableEntity } from '../../../shared/entities/extends/auditable-entity.entity';
+
+@Entity('levers')
+export class Lever {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ type: 'text', nullable: true })
+  short_name: string;
+
+  @Column({ type: 'text', nullable: true })
+  full_name: string;
+
+  //auditable fields
+
+  @Exclude()
+  @Column(() => AuditableEntity, { prefix: '' })
+  auditableFields: AuditableEntity;
+}

--- a/clarisa-back/src/api/lever/lever.controller.spec.ts
+++ b/clarisa-back/src/api/lever/lever.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeverController } from './lever.controller';
+import { LeverService } from './lever.service';
+
+describe('LeverController', () => {
+  let controller: LeverController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LeverController],
+      providers: [LeverService],
+    }).compile();
+
+    controller = module.get<LeverController>(LeverController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/clarisa-back/src/api/lever/lever.controller.ts
+++ b/clarisa-back/src/api/lever/lever.controller.ts
@@ -1,0 +1,27 @@
+import {
+  Controller,
+  Get,
+  Param,
+  UseInterceptors,
+  ClassSerializerInterceptor,
+  Query,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { LeverService } from './lever.service';
+import { FindAllOptions } from '../../shared/entities/enums/find-all-options';
+
+@Controller()
+@UseInterceptors(ClassSerializerInterceptor)
+export class LeverController {
+  constructor(private readonly _leverService: LeverService) {}
+
+  @Get()
+  async findAll(@Query('show') show: FindAllOptions) {
+    return await this._leverService.findAll(show);
+  }
+
+  @Get('get/:id')
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return await this._leverService.findOne(id);
+  }
+}

--- a/clarisa-back/src/api/lever/lever.module.ts
+++ b/clarisa-back/src/api/lever/lever.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LeverService } from './lever.service';
+import { LeverController } from './lever.controller';
+import { LeverRepository } from './repositories/lever.repository';
+
+@Module({
+  controllers: [LeverController],
+  providers: [LeverService, LeverRepository],
+})
+export class LeverModule {}

--- a/clarisa-back/src/api/lever/lever.service.spec.ts
+++ b/clarisa-back/src/api/lever/lever.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeverService } from './lever.service';
+
+describe('LeverService', () => {
+  let service: LeverService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LeverService],
+    }).compile();
+
+    service = module.get<LeverService>(LeverService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/clarisa-back/src/api/lever/lever.service.ts
+++ b/clarisa-back/src/api/lever/lever.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { LeverRepository } from './repositories/lever.repository';
+import { FindAllOptions } from '../../shared/entities/enums/find-all-options';
+import { Lever } from './entities/lever.entity';
+
+@Injectable()
+export class LeverService {
+  constructor(private readonly _leversRepository: LeverRepository) {}
+
+  async findAll(option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE) {
+    let response: Lever[];
+    switch (option) {
+      case FindAllOptions.SHOW_ALL:
+        response = await this._leversRepository.find();
+        break;
+      case FindAllOptions.SHOW_ONLY_ACTIVE:
+      case FindAllOptions.SHOW_ONLY_INACTIVE:
+        response = await this._leversRepository.find({
+          where: {
+            auditableFields: {
+              is_active: option === FindAllOptions.SHOW_ONLY_ACTIVE,
+            },
+          },
+        });
+        break;
+      default:
+        throw Error('?!');
+    }
+
+    return response;
+  }
+
+  async findOne(id: number): Promise<Lever> {
+    return await this._leversRepository.findOneBy({
+      id,
+      auditableFields: { is_active: true },
+    });
+  }
+}

--- a/clarisa-back/src/api/lever/repositories/lever.repository.ts
+++ b/clarisa-back/src/api/lever/repositories/lever.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Lever } from '../entities/lever.entity';
+
+@Injectable()
+export class LeverRepository extends Repository<Lever> {
+  constructor(private dataSource: DataSource) {
+    super(Lever, dataSource.createEntityManager());
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing "alliance levers" in the `clarisa-back` project. It includes database migrations, new modules, and associated services, controllers, and repositories.

### Database Changes:
* Added a migration to create the `levers` table and insert initial data. (`clarisa-back/migrations/1729007797004-addAllianceLevers.ts`)

### Module Integration:
* Added `LeverModule` to `ApiModule` and `apiRoutes` to integrate the new feature into the existing API structure. (`clarisa-back/src/api/api.module.ts`, `clarisa-back/src/api/api.routes.ts`) [[1]](diffhunk://#diff-766593abb9d6428babe0d2f25411b3c4766e4ac0873a86f1d9c1de8582b41309R83) [[2]](diffhunk://#diff-766593abb9d6428babe0d2f25411b3c4766e4ac0873a86f1d9c1de8582b41309R166) [[3]](diffhunk://#diff-4740843e479e6cba21418f5f1c8a2283fbb38f01004860c7a8c75c8777822a32R77) [[4]](diffhunk://#diff-4740843e479e6cba21418f5f1c8a2283fbb38f01004860c7a8c75c8777822a32R384-R387)

### Entity Definition:
* Defined the `Lever` entity with fields for `id`, `short_name`, `full_name`, and auditable fields. (`clarisa-back/src/api/lever/entities/lever.entity.ts`)

### Service and Controller:
* Implemented `LeverService` to handle business logic and `LeverController` to manage HTTP requests related to levers. (`clarisa-back/src/api/lever/lever.service.ts`, `clarisa-back/src/api/lever/lever.controller.ts`) [[1]](diffhunk://#diff-54b0fe98c48228343f39da1f843aa09b2e9e99d2dfe3771cc140d0c98789b797R1-R27) [[2]](diffhunk://#diff-1e9835f7adcdfc327f1f6946cd95892bcabfb974d1a2603dacd1b0eb83b48583R1-R39)

### Repository:
* Created `LeverRepository` to interact with the `levers` table in the database. (`clarisa-back/src/api/lever/repositories/lever.repository.ts`)

### Testing:
* Added unit tests for `LeverService` and `LeverController`. (`clarisa-back/src/api/lever/lever.service.spec.ts`, `clarisa-back/src/api/lever/lever.controller.spec.ts`) [[1]](diffhunk://#diff-9d392242350b3546885d159ce78f7de8d52902c1704a93c1fac2b467fd3b1660R1-R18) [[2]](diffhunk://#diff-cc84b834c57c73bac1b24819cdcfd372a72f1f674d1c6c160b008b17e13dc39bR1-R20)