### PR TITLE
🐛fix(DB Connection): changing env attribute to read the port from

### DIFF
--- a/toc-integration/src/database/db.ts
+++ b/toc-integration/src/database/db.ts
@@ -19,7 +19,7 @@ export class Database {
       const dataSourceOptions: DataSourceOptions = {
         type: "mysql",
         host: env.DB_HOST,
-        port: parseInt(env.DB_HOST),
+        port: parseInt(env.DB_PORT),
         username: env.DB_USER_NAME,
         password: env.DB_USER_PASS,
         database: env.DB_NAME,


### PR DESCRIPTION
This pull request includes a critical bug fix in the `Database` class of the `toc-integration` module. The change corrects the port configuration for the MySQL database connection.

Bug Fix:

* [`toc-integration/src/database/db.ts`](diffhunk://#diff-91f5b891cf3acab2f332211f5a60930548ef7c123b1e7c23e80d92d071b8fdb7L22-R22): Changed the port configuration to correctly use `env.DB_PORT` instead of `env.DB_HOST`.