### PR TITLE
♻️  refactor(OpenSearch): enhance subnational data structure and query methods

### DIFF
--- a/clarisa-back/src/api/subnational-scope/repositories/subnational-scope.repository.ts
+++ b/clarisa-back/src/api/subnational-scope/repositories/subnational-scope.repository.ts
@@ -18,24 +18,12 @@ export class SubnationalScopeRepository
 
   findDataForOpenSearch(
     option: FindAllOptions,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ids?: number[],
   ): Promise<OpenSearchSubnationalDto[]> {
-    const query = `select 
-                  	iss.id,
-                  	iss.code,
-                  	iss.name,
-                  	iss.local_name,
-                  	iss.romanization_system_name,
-                  	c.iso_alpha_2,
-                  	iss.iso_language_id
-                  from iso_subnational_scope iss 
-                  	inner join countries c on iss.country_id = c.id 
-                  where 1 = 1 
-                  	${option !== FindAllOptions.SHOW_ALL ? 'and iss.is_active = true' : ''}
-                    ${ids && ids.length > 0 ? `and iss.id IN (${ids.join(',')})` : ''}
-                  `;
-
-    return this.query(query);
+    return this.findSubnationalScope(option) as unknown as Promise<
+      OpenSearchSubnationalDto[]
+    >;
   }
 
   async findSubnationalScope(

--- a/clarisa-back/src/integration/opensearch/subnational/dto/open-search-subnational.dto.ts
+++ b/clarisa-back/src/integration/opensearch/subnational/dto/open-search-subnational.dto.ts
@@ -1,5 +1,19 @@
 import { OpenSearchProperty } from '../../decorators/opensearch-property.decorator';
 
+export class OtherNamesDto {
+  @OpenSearchProperty({ type: 'text' })
+  public name: string;
+
+  @OpenSearchProperty({ type: 'text' })
+  public local_name: string;
+
+  @OpenSearchProperty({ type: 'text' })
+  public language_iso_2: string;
+
+  @OpenSearchProperty({ type: 'text' })
+  public romanization_system_name: string;
+}
+
 export class OpenSearchSubnationalDto {
   @OpenSearchProperty({ type: 'integer' })
   public id: number;
@@ -10,15 +24,30 @@ export class OpenSearchSubnationalDto {
   @OpenSearchProperty({ type: 'text' })
   public name: string;
 
+  @OpenSearchProperty({ type: 'integer' })
+  public is_active: number;
+
+  @OpenSearchProperty({ type: 'integer' })
+  public country_id: number;
+
   @OpenSearchProperty({ type: 'text' })
   public local_name: string;
+
+  @OpenSearchProperty({ type: 'nested', nestedType: OtherNamesDto })
+  public other_names: OtherNamesDto[];
+
+  @OpenSearchProperty({ type: 'text' })
+  public country_name: string;
+
+  @OpenSearchProperty({ type: 'text' })
+  public language_iso_2: string;
+
+  @OpenSearchProperty({ type: 'keyword' })
+  public country_iso_alpha_2: string;
 
   @OpenSearchProperty({ type: 'text' })
   public romanization_system_name: string;
 
-  @OpenSearchProperty({ type: 'keyword' })
-  public iso_alpha_2: string;
-
-  @OpenSearchProperty({ type: 'integer' })
-  public iso_language_id: number;
+  @OpenSearchProperty({ type: 'text' })
+  public subnational_category_name: string;
 }

--- a/clarisa-back/src/integration/opensearch/subnational/open-search-subnational.controller.ts
+++ b/clarisa-back/src/integration/opensearch/subnational/open-search-subnational.controller.ts
@@ -38,7 +38,7 @@ export class OpenSearchSubnationalController {
       ],
       size,
       isoAlpha2,
-      'iso_alpha_2',
+      'country_iso_alpha_2',
     );
   }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling and structure of subnational scope data in the `clarisa-back` project. The most important changes involve refactoring the query method, updating the DTOs, and modifying the controller to use the new DTO properties.

### Refactoring and simplification:

* [`clarisa-back/src/api/subnational-scope/repositories/subnational-scope.repository.ts`](diffhunk://#diff-6eedcd0761f8d691600716c7665f9338ec3ac71255bda94e32ac7935c094cbfcR21-R26): Refactored the `findDataForOpenSearch` method to use `findSubnationalScope` instead of a raw SQL query.

### DTO enhancements:

* [`clarisa-back/src/integration/opensearch/subnational/dto/open-search-subnational.dto.ts`](diffhunk://#diff-a0e3d334c011940e0dcccf7face3dd25a51e1a97319e0028931e962cce163f45R3-R16): Added a new `OtherNamesDto` class and updated the `OpenSearchSubnationalDto` class to include new properties such as `is_active`, `country_id`, `other_names`, `country_name`, `language_iso_2`, `country_iso_alpha_2`, and `subnational_category_name`. [[1]](diffhunk://#diff-a0e3d334c011940e0dcccf7face3dd25a51e1a97319e0028931e962cce163f45R3-R16) [[2]](diffhunk://#diff-a0e3d334c011940e0dcccf7face3dd25a51e1a97319e0028931e962cce163f45R27-R52)

### Controller update:

* [`clarisa-back/src/integration/opensearch/subnational/open-search-subnational.controller.ts`](diffhunk://#diff-8041c2a2cda3d46e85f22521fda273055e2958ca875a229183ac6b6734846c0fL41-R41): Updated the `OpenSearchSubnationalController` to use the new `country_iso_alpha_2` property instead of `iso_alpha_2`.