### PR TITLE
♻️ refactor(ImpactAreaIndicator): add portfolio and parent relationships, and enhance findAll method with versioning

### DIFF
--- a/clarisa-back/migrations/1743113089530-addedNewFieldsImpactAreaIndicator.ts
+++ b/clarisa-back/migrations/1743113089530-addedNewFieldsImpactAreaIndicator.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedNewFieldsImpactAreaIndicator1743113089530
+  implements MigrationInterface
+{
+  name = 'AddedNewFieldsImpactAreaIndicator1743113089530';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` ADD \`portfolio_id\` bigint NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` ADD \`parent_id\` bigint NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` ADD \`level\` bigint NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` ADD CONSTRAINT \`FK_fbf375068e8a9ff9c3baa47463c\` FOREIGN KEY (\`parent_id\`) REFERENCES \`impact_area_indicators\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` ADD CONSTRAINT \`FK_3fcd5630b16d452bec77fb65521\` FOREIGN KEY (\`portfolio_id\`) REFERENCES \`portfolios\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` DROP FOREIGN KEY \`FK_3fcd5630b16d452bec77fb65521\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` DROP FOREIGN KEY \`FK_fbf375068e8a9ff9c3baa47463c\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` DROP COLUMN \`level\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` DROP COLUMN \`parent_id\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` DROP COLUMN \`portfolio_id\``,
+    );
+  }
+}

--- a/clarisa-back/src/api/impact-area-indicator/dto/impact-area-indicator.dto.ts
+++ b/clarisa-back/src/api/impact-area-indicator/dto/impact-area-indicator.dto.ts
@@ -1,3 +1,5 @@
+import { Portfolio } from '../../portfolio/entities/portfolio.entity';
+
 export class ImpactAreaIndicatorDto {
   indicatorId: number;
   indicatorStatement: string;
@@ -7,4 +9,9 @@ export class ImpactAreaIndicatorDto {
   targetUnit: string;
   value: string;
   isAplicableProjectedBenefits: boolean;
+  portfolioId?: number;
+  portfolio?: Partial<Portfolio>;
+  parentId?: number;
+  parent?: Partial<ImpactAreaIndicatorDto>;
+  level?: number;
 }

--- a/clarisa-back/src/api/impact-area-indicator/entities/impact-area-indicator.entity.ts
+++ b/clarisa-back/src/api/impact-area-indicator/entities/impact-area-indicator.entity.ts
@@ -4,10 +4,12 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { AuditableEntity } from '../../../shared/entities/extends/auditable-entity.entity';
 import { ImpactArea } from '../../impact-area/entities/impact-area.entity';
+import { Portfolio } from '../../portfolio/entities/portfolio.entity';
 
 @Entity('impact_area_indicators')
 export class ImpactAreaIndicator {
@@ -37,11 +39,31 @@ export class ImpactAreaIndicator {
   @Column({ type: 'bigint', nullable: true })
   impact_areas_id: number;
 
+  @Column({ type: 'bigint', nullable: true })
+  portfolio_id: number;
+
+  @Column({ type: 'bigint', nullable: true })
+  parent_id: number;
+
+  @Column({ type: 'bigint', nullable: true })
+  level: number;
+
   //object relations
 
   @ManyToOne(() => ImpactArea, (ia) => ia.impact_area_indicators)
   @JoinColumn({ name: 'impact_areas_id' })
   impact_area_object: ImpactArea;
+
+  @ManyToOne(() => ImpactAreaIndicator, (iai) => iai.children)
+  @JoinColumn({ name: 'parent_id' })
+  parent: ImpactAreaIndicator;
+
+  @OneToMany(() => ImpactAreaIndicator, (iai) => iai.parent)
+  children: ImpactAreaIndicator[];
+
+  @ManyToOne(() => Portfolio, (p) => p.impact_area_indicators)
+  @JoinColumn({ name: 'portfolio_id' })
+  portfolio: Portfolio;
 
   //auditable fields
 

--- a/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.controller.ts
+++ b/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.controller.ts
@@ -26,8 +26,11 @@ export class ImpactAreaIndicatorController {
   ) {}
 
   @Get()
-  async findAll(@Query('show') show: FindAllOptions) {
-    return await this.impactAreaIndicatorService.findAll(show);
+  async findAll(
+    @Query('show') show: FindAllOptions,
+    @Query('version') version: string,
+  ) {
+    return await this.impactAreaIndicatorService.findAll(show, +version);
   }
 
   @Get('get/:id')

--- a/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.service.ts
+++ b/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.service.ts
@@ -13,6 +13,7 @@ export class ImpactAreaIndicatorService {
 
   async findAll(
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
+    version?: number,
   ): Promise<ImpactAreaIndicatorDto[]> {
     if (!Object.values<string>(FindAllOptions).includes(option)) {
       throw Error('?!');
@@ -20,6 +21,7 @@ export class ImpactAreaIndicatorService {
 
     return this.impactAreaIndicatorRepository.findAllImpactAreaIndicators(
       option,
+      version,
     );
   }
 

--- a/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
+++ b/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
@@ -11,6 +11,7 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
   }
   async findAllImpactAreaIndicators(
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
+    version?: number,
   ): Promise<ImpactAreaIndicatorDto[]> {
     const impactAreaIndicatorDtos: ImpactAreaIndicatorDto[] = [];
     let whereClause: FindOptionsWhere<ImpactAreaIndicator> = {};
@@ -37,6 +38,8 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
       where: whereClause,
       relations: {
         impact_area_object: true,
+        parent: true,
+        portfolio: true,
       },
     });
 
@@ -57,6 +60,26 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
         impactAreaIndicatorDto.targetUnit = iai.target_unit;
         impactAreaIndicatorDto.targetYear = iai.target_year;
         impactAreaIndicatorDto.value = iai.target_value;
+
+        if (version == 2) {
+          impactAreaIndicatorDto.portfolioId = iai.portfolio_id;
+          impactAreaIndicatorDto.parentId = iai.parent_id;
+          impactAreaIndicatorDto.level = iai.level;
+          impactAreaIndicatorDto.portfolio = iai.portfolio
+            ? {
+                id: iai.portfolio.id,
+                name: iai.portfolio.name,
+              }
+            : null;
+          impactAreaIndicatorDto.parent = iai.parent
+            ? {
+                impactAreaId: iai.parent.impact_areas_id,
+                impactAreaName: iai.parent.impact_area_object.name,
+                indicatorId: iai.parent.id,
+                indicatorStatement: iai.parent.indicator_statement,
+              }
+            : null;
+        }
 
         impactAreaIndicatorDtos.push(impactAreaIndicatorDto);
       }),

--- a/clarisa-back/src/api/portfolio/entities/portfolio.entity.ts
+++ b/clarisa-back/src/api/portfolio/entities/portfolio.entity.ts
@@ -3,6 +3,7 @@ import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { AuditableEntity } from '../../../shared/entities/extends/auditable-entity.entity';
 import { CgiarEntityType } from '../../cgiar-entity-type/entities/cgiar-entity-type.entity';
 import { CgiarEntity } from '../../cgiar-entity/entities/cgiar-entity.entity';
+import { ImpactAreaIndicator } from '../../impact-area-indicator/entities/impact-area-indicator.entity';
 
 @Entity('portfolios')
 export class Portfolio {
@@ -24,6 +25,9 @@ export class Portfolio {
 
   @OneToMany(() => CgiarEntity, (ce) => ce.portfolio_object)
   cgiar_entity_array: CgiarEntity[];
+
+  @OneToMany(() => ImpactAreaIndicator, (iai) => iai.portfolio)
+  impact_area_indicators: ImpactAreaIndicator[];
 
   //auditable fields
 


### PR DESCRIPTION
This pull request includes changes to add new fields and relationships to the `ImpactAreaIndicator` entity, update related DTOs and services, and adjust the repository to handle the new fields and relationships.

### Database Schema Changes:
* Added new fields `portfolio_id`, `parent_id`, and `level` to the `impact_area_indicators` table, and created foreign key constraints for `parent_id` and `portfolio_id`.

### Entity and DTO Updates:
* Updated the `ImpactAreaIndicator` entity to include the new fields and their relationships with `Portfolio` and `ImpactAreaIndicator`.
* Updated the `ImpactAreaIndicatorDto` to include optional fields for `portfolioId`, `portfolio`, `parentId`, `parent`, and `level`.

### Service and Repository Changes:
* Modified the `ImpactAreaIndicatorService` to accept an optional `version` parameter in the `findAll` method.
* Updated the `ImpactAreaIndicatorRepository` to handle the new fields and relationships, and to include them in the `findAllImpactAreaIndicators` method if `version` is 2.

### Portfolio Entity Update:
* Added a one-to-many relationship with `ImpactAreaIndicator` in the `Portfolio` entity.