### PR TITLE
Modification of impact area indicator services

### DIFF
--- a/clarisa-back/migrations/1743460009079-resizeImpactAreaIndicatorField.ts
+++ b/clarisa-back/migrations/1743460009079-resizeImpactAreaIndicatorField.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ResizeImpactAreaIndicatorField1743460009079
+  implements MigrationInterface
+{
+  name = 'ResizeImpactAreaIndicatorField1743460009079';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` CHANGE COLUMN \`indicator_statement\` \`indicator_statement\` VARCHAR(200) NULL;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`impact_area_indicators\` CHANGE COLUMN \`indicator_statement\` \`indicator_statement\` VARCHAR(100) NULL;`,
+    );
+  }
+}

--- a/clarisa-back/src/api/impact-area-indicator/dto/impact-area-indicator.dto.ts
+++ b/clarisa-back/src/api/impact-area-indicator/dto/impact-area-indicator.dto.ts
@@ -14,4 +14,5 @@ export class ImpactAreaIndicatorDto {
   parentId?: number;
   parent?: Partial<ImpactAreaIndicatorDto>;
   level?: number;
+  smoCode?: string;
 }

--- a/clarisa-back/src/api/impact-area-indicator/entities/impact-area-indicator.entity.ts
+++ b/clarisa-back/src/api/impact-area-indicator/entities/impact-area-indicator.entity.ts
@@ -16,7 +16,7 @@ export class ImpactAreaIndicator {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ type: 'varchar', length: 100, nullable: true })
+  @Column({ type: 'varchar', length: 200, nullable: true })
   indicator_statement: string;
 
   @Column({ type: 'int', nullable: true })

--- a/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
+++ b/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
@@ -60,9 +60,9 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
         impactAreaIndicatorDto.targetUnit = iai.target_unit;
         impactAreaIndicatorDto.targetYear = iai.target_year;
         impactAreaIndicatorDto.value = iai.target_value;
-        impactAreaIndicatorDto.smoCode = iai?.smo_code;
 
         if (version == 2) {
+          impactAreaIndicatorDto.smoCode = iai?.smo_code;
           impactAreaIndicatorDto.portfolioId = iai.portfolio_id;
           impactAreaIndicatorDto.parentId = iai.parent_id;
           impactAreaIndicatorDto.level = iai.level;
@@ -75,7 +75,7 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
           impactAreaIndicatorDto.parent = iai.parent
             ? {
                 impactAreaId: iai?.parent?.impact_areas_id,
-                impactAreaName: iai?.parent?.impact_area_object.name,
+                impactAreaName: iai?.parent?.impact_area_object?.name,
                 indicatorId: iai?.parent?.id,
                 indicatorStatement: iai?.parent?.indicator_statement,
               }

--- a/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
+++ b/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
@@ -60,6 +60,7 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
         impactAreaIndicatorDto.targetUnit = iai.target_unit;
         impactAreaIndicatorDto.targetYear = iai.target_year;
         impactAreaIndicatorDto.value = iai.target_value;
+        impactAreaIndicatorDto.smoCode = iai?.smo_code;
 
         if (version == 2) {
           impactAreaIndicatorDto.portfolioId = iai.portfolio_id;
@@ -67,16 +68,16 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
           impactAreaIndicatorDto.level = iai.level;
           impactAreaIndicatorDto.portfolio = iai.portfolio
             ? {
-                id: iai.portfolio.id,
-                name: iai.portfolio.name,
+                id: iai?.portfolio?.id,
+                name: iai?.portfolio?.name,
               }
             : null;
           impactAreaIndicatorDto.parent = iai.parent
             ? {
-                impactAreaId: iai.parent.impact_areas_id,
-                impactAreaName: iai.parent.impact_area_object.name,
-                indicatorId: iai.parent.id,
-                indicatorStatement: iai.parent.indicator_statement,
+                impactAreaId: iai?.parent?.impact_areas_id,
+                impactAreaName: iai?.parent?.impact_area_object.name,
+                indicatorId: iai?.parent?.id,
+                indicatorStatement: iai?.parent?.indicator_statement,
               }
             : null;
         }


### PR DESCRIPTION
This pull request includes several changes to the `ImpactAreaIndicator` component in the `clarisa-back` project. The key changes involve resizing a field in the database, updating the corresponding entity and DTO, and adding a new property to the DTO and repository.

Database migration:

* [`clarisa-back/migrations/1743460009079-resizeImpactAreaIndicatorField.ts`](diffhunk://#diff-b8194682ae89ae1ceeda8a520a43b3c0554f9d3e60d724bdaf27c747cecb0e35R1-R19): Added a migration to resize the `indicator_statement` field in the `impact_area_indicators` table from 100 to 200 characters.

Entity and DTO updates:

* [`clarisa-back/src/api/impact-area-indicator/entities/impact-area-indicator.entity.ts`](diffhunk://#diff-733006d3abc0aa2a2d01da8911548eb21770470c95752893d4affb291e3fe318L19-R19): Updated the `indicator_statement` field in the `ImpactAreaIndicator` entity to match the new size of 200 characters.
* [`clarisa-back/src/api/impact-area-indicator/dto/impact-area-indicator.dto.ts`](diffhunk://#diff-43aaa8c01d4279416ef00755690f5999444a4fe97f756c21717c5026fde34b6eR17): Added a new `smoCode` property to the `ImpactAreaIndicatorDto` class.

Repository changes:

* [`clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts`](diffhunk://#diff-02dfa09695e213e38416dbc349802cae75070c20d0fc2d771065f6184b431bfcR65-R80): Updated the repository to include the new `smoCode` property and modified the code to use optional chaining for better null safety.