### PR TITLE
♻️ refactor(ImpactAreaIndicator): add portfolio parameter to findAll methods in controller, service, and repository

### DIFF
--- a/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.controller.ts
+++ b/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.controller.ts
@@ -29,8 +29,13 @@ export class ImpactAreaIndicatorController {
   async findAll(
     @Query('show') show: FindAllOptions,
     @Query('version') version: string,
+    @Query('portfolio') portfolio: string,
   ) {
-    return await this.impactAreaIndicatorService.findAll(show, +version);
+    return await this.impactAreaIndicatorService.findAll(
+      show,
+      +version,
+      +portfolio,
+    );
   }
 
   @Get('get/:id')

--- a/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.service.ts
+++ b/clarisa-back/src/api/impact-area-indicator/impact-area-indicator.service.ts
@@ -14,6 +14,7 @@ export class ImpactAreaIndicatorService {
   async findAll(
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
     version?: number,
+    portfolio?: number,
   ): Promise<ImpactAreaIndicatorDto[]> {
     if (!Object.values<string>(FindAllOptions).includes(option)) {
       throw Error('?!');
@@ -22,6 +23,7 @@ export class ImpactAreaIndicatorService {
     return this.impactAreaIndicatorRepository.findAllImpactAreaIndicators(
       option,
       version,
+      portfolio,
     );
   }
 

--- a/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
+++ b/clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts
@@ -12,6 +12,7 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
   async findAllImpactAreaIndicators(
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
     version?: number,
+    portfolioId?: number,
   ): Promise<ImpactAreaIndicatorDto[]> {
     const impactAreaIndicatorDtos: ImpactAreaIndicatorDto[] = [];
     let whereClause: FindOptionsWhere<ImpactAreaIndicator> = {};
@@ -32,6 +33,10 @@ export class ImpactAreaIndicatorRepository extends Repository<ImpactAreaIndicato
           },
         };
         break;
+    }
+
+    if (portfolioId && version === 2) {
+      whereClause.portfolio_id = portfolioId;
     }
 
     const impactAreaIndicators: ImpactAreaIndicator[] = await this.find({


### PR DESCRIPTION
This pull request introduces changes to the `ImpactAreaIndicator` feature in the `clarisa-back` project to include a new `portfolio` parameter in the `findAll` method across the controller, service, and repository layers. The most important changes include the addition of the `portfolio` parameter and the necessary updates to handle this parameter in the respective classes.

Changes to include the `portfolio` parameter:

* [`clarisa-back/src/api/impact-area-indicator/impact-area-indicator.controller.ts`](diffhunk://#diff-8215ae8ce01a7be88f086d1928c6d3529ec8fbec5f8c38452812ad1f740623a2R32-R38): Added `portfolio` query parameter to the `findAll` method and updated the call to `impactAreaIndicatorService.findAll` to include this new parameter.
* [`clarisa-back/src/api/impact-area-indicator/impact-area-indicator.service.ts`](diffhunk://#diff-259f36de48979eb3adb8d565f0e71b836fa9c1255d4291a308d28e8e3f8f0deaR17): Added `portfolio` parameter to the `findAll` method and updated the call to `impactAreaIndicatorRepository.findAllImpactAreaIndicators` to include this new parameter. [[1]](diffhunk://#diff-259f36de48979eb3adb8d565f0e71b836fa9c1255d4291a308d28e8e3f8f0deaR17) [[2]](diffhunk://#diff-259f36de48979eb3adb8d565f0e71b836fa9c1255d4291a308d28e8e3f8f0deaR26)
* [`clarisa-back/src/api/impact-area-indicator/repositories/impact-area-indicator.repository.ts`](diffhunk://#diff-02dfa09695e213e38416dbc349802cae75070c20d0fc2d771065f6184b431bfcR15): Added `portfolioId` parameter to the `findAllImpactAreaIndicators` method and updated the method to filter by `portfolio_id` when `portfolioId` is provided and `version` is 2. [[1]](diffhunk://#diff-02dfa09695e213e38416dbc349802cae75070c20d0fc2d771065f6184b431bfcR15) [[2]](diffhunk://#diff-02dfa09695e213e38416dbc349802cae75070c20d0fc2d771065f6184b431bfcR38-R41)