### PR TITLE
Partner acceptance mailing updated

### DIFF
--- a/clarisa-back/migrations/1741798484342-addingPlatformUrl.ts
+++ b/clarisa-back/migrations/1741798484342-addingPlatformUrl.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddingPlatformUrl1741798484342 implements MigrationInterface {
+  name = 'AddingPlatformUrl1741798484342';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`partner_requests\` ADD \`platform_url\` text NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`partner_requests\` DROP COLUMN \`platform_url\``,
+    );
+  }
+}

--- a/clarisa-back/src/api/partner-request/dto/create-partner-request.dto.ts
+++ b/clarisa-back/src/api/partner-request/dto/create-partner-request.dto.ts
@@ -32,4 +32,6 @@ export class CreatePartnerRequestDto {
   category_1?: string;
 
   category_2?: string;
+
+  platformUrl?: string;
 }

--- a/clarisa-back/src/api/partner-request/entities/partner-request.entity.ts
+++ b/clarisa-back/src/api/partner-request/entities/partner-request.entity.ts
@@ -64,6 +64,9 @@ export class PartnerRequest {
   @Column({ type: 'text', nullable: true })
   category_2: string;
 
+  @Column({ type: 'text', nullable: true })
+  platform_url: string;
+
   //relations
 
   @Column({ type: 'bigint', nullable: true })

--- a/clarisa-back/src/api/partner-request/repositories/partner-request.repository.ts
+++ b/clarisa-back/src/api/partner-request/repositories/partner-request.repository.ts
@@ -346,9 +346,14 @@ export class PartnerRequestRepository extends Repository<PartnerRequest> {
       ? partialPartnerRequest.accepted_by
       : partialPartnerRequest.rejected_by;
 
+    const emailPartener = { ...partialPartnerRequest };
+
+    emailPartener['platformUrl'] = emailPartener.platform_url;
+    emailPartener['misAcronym'] = emailPartener.mis_object.acronym;
+
     this.messageMicroservice.sendPartnerRequestEmail(
       EmailTemplate.PARTNER_REQUEST_RESPONSE,
-      partialPartnerRequest,
+      emailPartener,
     );
 
     if (accepted) {

--- a/clarisa-back/src/api/partner-request/repositories/partner-request.repository.ts
+++ b/clarisa-back/src/api/partner-request/repositories/partner-request.repository.ts
@@ -301,6 +301,7 @@ export class PartnerRequestRepository extends Repository<PartnerRequest> {
 
     partialPartnerRequest.category_1 = incomingPartnerRequest.category_1;
     partialPartnerRequest.category_2 = incomingPartnerRequest.category_2;
+    partialPartnerRequest.platform_url = incomingPartnerRequest.platformUrl;
 
     partialPartnerRequest.auditableFields.is_active = false;
     partialPartnerRequest = await this.save(partialPartnerRequest);


### PR DESCRIPTION
This pull request introduces a new `platform_url` field to the `partner_requests` table and updates the related classes and repository to support this addition. The changes ensure that the new field is integrated into the database schema, DTOs, entity definitions, and repository logic.

### Database Schema Update:

* [`clarisa-back/migrations/1741798484342-addingPlatformUrl.ts`](diffhunk://#diff-a5655dc2cbdb42725b3c73865994a39d045ccec87eb434652308d1fff82fe172R1-R17): Added a migration to include the `platform_url` column in the `partner_requests` table, allowing it to store nullable text values.

### DTO and Entity Updates:

* [`clarisa-back/src/api/partner-request/dto/create-partner-request.dto.ts`](diffhunk://#diff-8c9a7b17f66e0df7bed4896928c7849b77ee297bbf0c9fe3568a8be4b384965eR35-R36): Added the `platformUrl` field to the `CreatePartnerRequestDto` class to handle the new field in incoming requests.
* [`clarisa-back/src/api/partner-request/entities/partner-request.entity.ts`](diffhunk://#diff-88de4ad718a06d799ab99859df67046ef573aaba176e4637c2d6216e329eb844R67-R69): Added the `platform_url` column to the `PartnerRequest` entity to match the database schema.

### Repository Logic Adjustments:

* `clarisa-back/src/api/partner-request/repositories/partner-request.repository.ts`: 
  - Mapped the `platform_url` field between the entity and incoming requests in the repository logic.
  - Updated the email preparation logic to include `platformUrl` in the email payload, ensuring consistency in naming conventions for outgoing emails.