### PR TITLE
* Feat add MIS Auth metadata

### DIFF
--- a/clarisa-back/migrations/1747076648155-addAuthMisesTable.ts
+++ b/clarisa-back/migrations/1747076648155-addAuthMisesTable.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAuthMisesTable1747076648155 implements MigrationInterface {
+    name = 'AddAuthMisesTable1747076648155'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`mises_auth\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`mis_id\` bigint NOT NULL, \`auth_url\` text NOT NULL, \`cognito_client_id\` text NOT NULL, \`cognito_client_secret\` text NOT NULL, UNIQUE INDEX \`REL_d168856577ccc50c23514b3de4\` (\`mis_id\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`mises_auth\` ADD CONSTRAINT \`FK_d168856577ccc50c23514b3de4c\` FOREIGN KEY (\`mis_id\`) REFERENCES \`mises\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`mises_auth\` DROP FOREIGN KEY \`FK_d168856577ccc50c23514b3de4c\``);
+        await queryRunner.query(`DROP INDEX \`REL_d168856577ccc50c23514b3de4\` ON \`mises_auth\``);
+        await queryRunner.query(`DROP TABLE \`mises_auth\``);
+    }
+
+}

--- a/clarisa-back/src/api/mis/entities/mis.entity.ts
+++ b/clarisa-back/src/api/mis/entities/mis.entity.ts
@@ -5,6 +5,7 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { AuditableEntity } from '../../../shared/entities/extends/auditable-entity.entity';
@@ -14,6 +15,7 @@ import { UserMis } from '../../user/entities/user-mis.entity';
 import { User } from '../../user/entities/user.entity';
 import { Environment } from '../../environment/entities/environment.entity';
 import { AppSecret } from '../../app-secret/entities/app-secret.entity';
+import { MisAuth } from './mises-auth.entity';
 
 @Entity('mises')
 export class Mis {
@@ -58,6 +60,9 @@ export class Mis {
 
   @OneToMany(() => UserMis, (um) => um.mis_object)
   user_mis_array: UserMis[];
+
+  @OneToOne(() => MisAuth, (ma) => ma.mis_object)
+  mis_auth: MisAuth;
 
   //auditable fields
 

--- a/clarisa-back/src/api/mis/entities/mises-auth.entity.ts
+++ b/clarisa-back/src/api/mis/entities/mises-auth.entity.ts
@@ -12,7 +12,7 @@ export class MisAuth {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ type: 'number', nullable: false })
+  @Column({ type: 'bigint', nullable: false })
   mis_id: number;
 
   @OneToOne(() => Mis, (m) => m.mis_auth)

--- a/clarisa-back/src/api/mis/entities/mises-auth.entity.ts
+++ b/clarisa-back/src/api/mis/entities/mises-auth.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Mis } from './mis.entity';
+
+@Entity('mises_auth')
+export class MisAuth {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ type: 'number', nullable: false })
+  mis_id: number;
+
+  @OneToOne(() => Mis, (m) => m.mis_auth)
+  @JoinColumn({ name: 'mis_id' })
+  mis_object: Mis;
+
+  @Column({ type: 'text', nullable: false })
+  auth_url: string;
+
+  @Column({ type: 'text', nullable: false })
+  cognito_client_id: string;
+
+  @Column({ type: 'text', nullable: false })
+  cognito_client_secret: string;
+}

--- a/clarisa-back/src/api/mis/mis.controller.ts
+++ b/clarisa-back/src/api/mis/mis.controller.ts
@@ -41,4 +41,10 @@ export class MisController {
   async findOne(@Param('id', ParseIntPipe) id: number) {
     return await this._misService.findOne(id);
   }
+
+  @Get('get-metadata/:id')
+  @UseGuards(JwtAuthGuard)
+  async findMetadataById(@Param('id', ParseIntPipe) id: number) {
+    return await this._misService.findMetadataById(id);
+  }
 }

--- a/clarisa-back/src/api/mis/mis.service.ts
+++ b/clarisa-back/src/api/mis/mis.service.ts
@@ -22,6 +22,7 @@ export class MisService {
   private readonly _where: FindManyOptions<Mis> = {
     relations: {
       environment_object: true,
+      mis_auth: true,
     },
   };
 

--- a/clarisa-back/src/api/mis/mis.service.ts
+++ b/clarisa-back/src/api/mis/mis.service.ts
@@ -22,7 +22,6 @@ export class MisService {
   private readonly _where: FindManyOptions<Mis> = {
     relations: {
       environment_object: true,
-      mis_auth: true,
     },
   };
 
@@ -135,6 +134,18 @@ export class MisService {
         auditableFields: { is_active: true },
       },
       ...this._where,
+    });
+  }
+
+  async findMetadataById(id: number): Promise<Mis> {
+    return await this._misRepository.findOne({
+      where: {
+        id,
+        auditableFields: { is_active: true },
+      },
+      relations: {
+        mis_auth: true,
+      },
     });
   }
 }


### PR DESCRIPTION
This pull request introduces a new feature to manage authentication metadata for `Mis` entities in the `clarisa-back` project. It includes the creation of a new table, entity, and associated relationships, as well as updates to the service and controller layers to support fetching authentication metadata. Below are the key changes grouped by theme:

### Database Changes:
* Created a new table `mises_auth` with fields for `auth_url`, `cognito_client_id`, and `cognito_client_secret`. Added a foreign key constraint linking `mis_id` to the `mises` table. (`clarisa-back/migrations/1747076648155-addAuthMisesTable.ts`)

### Entity Updates:
* Added a new entity `MisAuth` to represent the `mises_auth` table, including fields for `auth_url`, `cognito_client_id`, and `cognito_client_secret`, and a `OneToOne` relationship with the `Mis` entity. (`clarisa-back/src/api/mis/entities/mises-auth.entity.ts`)
* Updated the `Mis` entity to include a `OneToOne` relationship with the new `MisAuth` entity. (`clarisa-back/src/api/mis/entities/mis.entity.ts`) [[1]](diffhunk://#diff-a1bf158d62c2fac8c3f3d71432dac97192730a654e9bf8b54c5394cb9d319311R8) [[2]](diffhunk://#diff-a1bf158d62c2fac8c3f3d71432dac97192730a654e9bf8b54c5394cb9d319311R18) [[3]](diffhunk://#diff-a1bf158d62c2fac8c3f3d71432dac97192730a654e9bf8b54c5394cb9d319311R64-R66)

### Service and Controller Enhancements:
* Added a new method `findMetadataById` in the `MisService` to fetch `Mis` entities along with their associated `MisAuth` metadata. (`clarisa-back/src/api/mis/mis.service.ts`)
* Introduced a new endpoint `GET /get-metadata/:id` in the `MisController` to expose the `findMetadataById` functionality, secured with `JwtAuthGuard`. (`clarisa-back/src/api/mis/mis.controller.ts`)