### PR TITLE
✨ feat: add Dockerfile for multi-stage build setup

### DIFF
--- a/clarisa-back/Dockerfile
+++ b/clarisa-back/Dockerfile
@@ -1,0 +1,37 @@
+#################### BASE STAGE ####################
+FROM node:20.13.1-alpine AS base
+
+WORKDIR /app
+COPY package*.json ./
+
+#################### DEVELOPMENT STAGE ####################
+FROM base AS development
+
+RUN npm install && npm install --save-dev @types/node
+
+COPY . .
+# RUN npm run migration:run
+
+RUN npm run build
+
+CMD ["npm", "run", "start"]
+
+#################### BUILD STAGE ####################
+FROM base AS build
+RUN npm ci --only=production
+COPY . .
+RUN npm run build
+
+#################### PRODUCTION STAGE ####################
+FROM --platform=linux/amd64 node:20.13.1-alpine AS production
+
+WORKDIR /app
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package*.json ./
+
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` for the `clarisa-back` service, implementing a multi-stage build process to optimize development, build, and production workflows. The file defines distinct stages for base setup, development, build, and production.

Key changes in the `Dockerfile`:

### Multi-stage build implementation:
* **Base stage**: Sets up the base environment using the `node:20.13.1-alpine` image, defines the working directory, and copies `package*.json` files for dependency management.
* **Development stage**: Installs both production and development dependencies, copies the source code, and builds the application for development purposes.
* **Build stage**: Installs production dependencies using `npm ci`, copies the source code, and builds the application for production.
* **Production stage**: Creates a production-ready image using `node:20.13.1-alpine`, sets up a non-root user, and copies the built application and dependencies from the `build` stage. Exposes port 3000 and specifies the command to run the application.