### PR TITLE
✨ feat: add Jenkins trigger workflow for backend and frontend jobs

### DIFF
--- a/.github/workflows/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/.github/workflows/jenkins-trigger.yml
@@ -1,0 +1,47 @@
+name: Trigger Jenkins Job (Testing)
+
+on:
+  push:
+    branches:
+      - "dev" # Solo push a rama dev
+  pull_request:
+    branches:
+      - "dev" # Solo PRs hacia dev
+  workflow_dispatch: # También manual
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Obtener y disparar BACKEND
+      - name: Get branch name and build Backend Jenkins URL
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          JENKINS_BACKEND_URL="https://automation.prms.cgiar.org/job/prms-clarisa-dev-server-docker/build"
+          echo "Backend Jenkins URL: $JENKINS_BACKEND_URL"
+          echo "JENKINS_BACKEND_URL=${JENKINS_BACKEND_URL}" >> $GITHUB_ENV
+
+      - name: Trigger Backend Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_BACKEND_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_BACKEND_URL: ${{ env.JENKINS_BACKEND_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+
+      # Obtener y disparar FRONTEND
+      - name: Get branch name and build Frontend Jenkins URL
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          JENKINS_FRONTEND_URL="https://automation.prms.cgiar.org/job/prms-clarisa-dev-client-docker/build"
+          echo "Frontend Jenkins URL: $JENKINS_FRONTEND_URL"
+          echo "JENKINS_FRONTEND_URL=${JENKINS_FRONTEND_URL}" >> $GITHUB_ENV
+
+      - name: Trigger Frontend Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_FRONTEND_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_FRONTEND_URL: ${{ env.JENKINS_FRONTEND_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to trigger Jenkins jobs for both the backend and frontend builds. The workflow supports automation on `dev` branch pushes, pull requests targeting `dev`, and manual triggers.

### New GitHub Actions Workflow:

* [`.github/workflows/jenkins-trigger.yml`](diffhunk://#diff-1c18921013876ea35a74ead9f213c18663285db52f637745d11c540ebe15777aR1-R47): Added a workflow named "Trigger Jenkins Job (Testing)" that automates Jenkins job triggers for backend and frontend builds. It supports branch pushes, pull requests to `dev`, and manual dispatches. The workflow dynamically constructs Jenkins URLs based on the branch name and uses GitHub secrets for authentication.