### PR TITLE
✨ Update Dockerfile to include Alpine dependencies for bcrypt compilation

### DIFF
--- a/clarisa-back/Dockerfile
+++ b/clarisa-back/Dockerfile
@@ -1,5 +1,14 @@
+
 #################### BASE STAGE ####################
+# Alternativa: usar imagen Ubuntu si Alpine da problemas
+# FROM node:20.13.1 AS base
 FROM node:20.13.1-alpine AS base
+
+# Para Alpine: instalar dependencias necesarias para compilar bcrypt
+RUN apk add --no-cache python3 make g++
+
+# Para Ubuntu (si cambias la imagen base):
+# RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
This pull request updates the `clarisa-back/Dockerfile` to improve compatibility and reliability when building dependencies, particularly for compiling native modules like `bcrypt`. The main focus is on ensuring the necessary build tools are present for Alpine-based images, and providing guidance for switching to Ubuntu if needed.

Build environment improvements:

* Added installation of required build dependencies (`python3`, `make`, `g++`) for Alpine Linux to ensure successful compilation of modules such as `bcrypt`.
* Included commented instructions for switching to an Ubuntu base image and installing equivalent dependencies, offering flexibility in case of issues with Alpine.