### PR TITLE
:rocket: feat(docker): add multi-stage Dockerfile for front-end and back-end with Nginx configuration

### DIFF
--- a/clarisa-back/Dockerfile
+++ b/clarisa-back/Dockerfile
@@ -1,0 +1,45 @@
+#################### BASE STAGE ####################
+# Alternativa: usar imagen Ubuntu si Alpine da problemas
+# FROM node:20.13.1 AS base
+FROM node:20.13.1-alpine AS base
+
+# Para Alpine: instalar dependencias necesarias para compilar bcrypt
+RUN apk add --no-cache python3 make g++
+
+# Para Ubuntu (si cambias la imagen base):
+# RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY package*.json ./
+
+#################### DEVELOPMENT STAGE ####################
+FROM base AS development
+
+RUN npm install && npm install --save-dev @types/node
+
+COPY . .
+# RUN npm run migration:run
+
+RUN npm run build
+
+CMD ["npm", "run", "start"]
+
+#################### BUILD STAGE ####################
+FROM base AS build
+RUN npm ci --only=production
+COPY . .
+RUN npm run build
+
+#################### PRODUCTION STAGE ####################
+FROM --platform=linux/amd64 node:20.13.1-alpine AS production
+
+WORKDIR /app
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package*.json ./
+
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/clarisa-front/Dockerfile
+++ b/clarisa-front/Dockerfile
@@ -1,0 +1,44 @@
+#################### BUILD STAGE ####################
+FROM node:20-alpine AS build
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Build in dev mode as per team requirement
+RUN npm run build
+
+#################### TESTING STAGE ####################
+FROM node:20-alpine AS test
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Run tests (adjust the script if needed)
+CMD ["npm", "run", "test:coverage"]
+
+#################### PRODUCTION STAGE ####################
+FROM nginx:alpine
+
+# Clean default Nginx html
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy custom Nginx config
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Copy built Angular app from build stage
+COPY --from=build /usr/src/app/dist/clarisa-front /usr/share/nginx/html
+
+# Permissions
+RUN chmod -R 755 /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/clarisa-front/nginx.conf
+++ b/clarisa-front/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes 1;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+  sendfile      on;
+  keepalive_timeout 65;
+
+  server {
+    listen       80;
+    server_name  localhost;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+
+    error_page 404 /index.html;
+  }
+}


### PR DESCRIPTION
This pull request introduces Docker support for both the backend (`clarisa-back`) and frontend (`clarisa-front`) projects, enabling consistent local development, testing, and production deployments. It adds multi-stage Dockerfiles for both projects, optimizing image size and security, and includes a custom Nginx configuration for serving the frontend Angular app.

**Backend Dockerization (`clarisa-back`):**
* Added a multi-stage Dockerfile with separate stages for development, build, and production, including necessary Alpine dependencies for compiling native modules like `bcrypt`.

**Frontend Dockerization (`clarisa-front`):**
* Introduced a multi-stage Dockerfile that builds the Angular app, supports testing, and serves the production build using Nginx.

**Frontend Server Configuration:**
* Added a custom `nginx.conf` to correctly serve the Angular app, handle client-side routing, and provide a fallback to `index.html` for 404 errors.