### PR TITLE
P2 1848 clarisa entity types does not show the new portfolio

### DIFF
--- a/clarisa-back/migrations/1759354373378-UpdateCgiarEntityTypeJsonStructure.ts
+++ b/clarisa-back/migrations/1759354373378-UpdateCgiarEntityTypeJsonStructure.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateCgiarEntityTypeJsonStructure1759354373378 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE hp_clarisa_endpoints
+            SET response_json = '{
+                "type": "response",
+                "order": null,
+                "properties": {
+                    "code": {
+                        "type": "number",
+                        "order": 0,
+                        "properties": null,
+                        "column_name": "Code",
+                        "object_type": "field",
+                        "show_in_table": true,
+                        "display_method": "inherit"
+                    },
+                    "name": {
+                        "type": "string",
+                        "order": 1,
+                        "properties": null,
+                        "column_name": "Name",
+                        "object_type": "field",
+                        "show_in_table": true,
+                        "display_method": "inherit"
+                    },
+                    "portfolio": {
+                        "type": "string",
+                        "order": 2,
+                        "properties": null,
+                        "column_name": "Portfolio",
+                        "object_type": "field",
+                        "show_in_table": true,
+                        "display_method": "inherit"
+                    }
+                },
+                "column_name": null,
+                "object_type": "list",
+                "show_in_table": false,
+                "display_method": "column"
+            }'
+            WHERE id = 2;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE hp_clarisa_endpoints
+            SET response_json = '{
+                "type": "response",
+                "order": null,
+                "properties": {
+                    "code": {
+                        "type": "number",
+                        "order": 0,
+                        "properties": null,
+                        "column_name": "Code",
+                        "object_type": "field",
+                        "show_in_table": true,
+                        "display_method": "inherit"
+                    },
+                    "name": {
+                        "type": "string",
+                        "order": 1,
+                        "properties": null,
+                        "column_name": "Name",
+                        "object_type": "field",
+                        "show_in_table": true,
+                        "display_method": "inherit"
+                    }
+                },
+                "column_name": null,
+                "object_type": "list",
+                "show_in_table": false,
+                "display_method": "column"
+            }'
+            WHERE id = 2;
+        `);
+    }
+
+}

--- a/clarisa-back/src/api/cgiar-entity-type/cgiar-entity-type.service.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/cgiar-entity-type.service.ts
@@ -71,8 +71,7 @@ export class CgiarEntityTypeService {
     }
 
     return this._cgiarEntityTypeMapper.entityTypeListToDtoV1List(
-      cgiarEntityTypes,
-      showIsActive,
+      cgiarEntityTypes
     );
   }
 

--- a/clarisa-back/src/api/cgiar-entity-type/cgiar-entity-type.service.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/cgiar-entity-type.service.ts
@@ -45,7 +45,6 @@ export class CgiarEntityTypeService {
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
   ): Promise<CgiarEntityTypeDtoV1[]> {
     let cgiarEntityTypes: CgiarEntityType[] = [];
-    let showIsActive = true;
     switch (option) {
       case FindAllOptions.SHOW_ALL:
         cgiarEntityTypes = await this._cgiarEntityTypeRepository.find({
@@ -55,7 +54,6 @@ export class CgiarEntityTypeService {
         break;
       case FindAllOptions.SHOW_ONLY_ACTIVE:
       case FindAllOptions.SHOW_ONLY_INACTIVE:
-        showIsActive = option !== FindAllOptions.SHOW_ONLY_ACTIVE;
         cgiarEntityTypes = await this._cgiarEntityTypeRepository.find({
           where: {
             ...this.whereClause,
@@ -71,7 +69,7 @@ export class CgiarEntityTypeService {
     }
 
     return this._cgiarEntityTypeMapper.entityTypeListToDtoV1List(
-      cgiarEntityTypes
+      cgiarEntityTypes,
     );
   }
 

--- a/clarisa-back/src/api/cgiar-entity-type/cgiar-entity-type.service.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/cgiar-entity-type.service.ts
@@ -7,6 +7,7 @@ import { CgiarEntityTypeRepository } from './repositories/cgiar-entity-type.repo
 import { BasicDto } from '../../shared/entities/dtos/basic-dto';
 import { CgiarEntityTypeMapper } from './mappers/cgiar-entity-type.mapper';
 import { CgiarEntityTypeDtoV2 } from './dto/cgiar-entity-type.v2.dto';
+import { CgiarEntityTypeDtoV1 } from './dto/cgiar-entity-type.v1.dto';
 
 @Injectable()
 export class CgiarEntityTypeService {
@@ -30,6 +31,10 @@ export class CgiarEntityTypeService {
     CgiarEntityTypeOption.INITIATIVE,
     CgiarEntityTypeOption.IMPACT_AREA_PLATFORM,
     CgiarEntityTypeOption.ONE_CGIAR_SGP,
+    CgiarEntityTypeOption.SCIENCE_PROGRAM,
+    CgiarEntityTypeOption.SCALING_PROGRAM,
+    CgiarEntityTypeOption.ACCELERATOR,
+    CgiarEntityTypeOption.KEY_AREA_OF_WORK,
   ].map((cet) => cet.entity_type_id);
 
   private readonly whereClause: FindOptionsWhere<CgiarEntityType> = {
@@ -38,13 +43,14 @@ export class CgiarEntityTypeService {
 
   async findAllV1(
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
-  ): Promise<BasicDto[]> {
+  ): Promise<CgiarEntityTypeDtoV1[]> {
     let cgiarEntityTypes: CgiarEntityType[] = [];
     let showIsActive = true;
     switch (option) {
       case FindAllOptions.SHOW_ALL:
         cgiarEntityTypes = await this._cgiarEntityTypeRepository.find({
           where: this.whereClause,
+          relations: { portfolio_object: true },
         });
         break;
       case FindAllOptions.SHOW_ONLY_ACTIVE:
@@ -57,13 +63,14 @@ export class CgiarEntityTypeService {
               is_active: option === FindAllOptions.SHOW_ONLY_ACTIVE,
             },
           },
+          relations: { portfolio_object: true },
         });
         break;
       default:
         throw Error('?!');
     }
 
-    return this._cgiarEntityTypeMapper.classListToDtoV1List(
+    return this._cgiarEntityTypeMapper.entityTypeListToDtoV1List(
       cgiarEntityTypes,
       showIsActive,
     );

--- a/clarisa-back/src/api/cgiar-entity-type/dto/cgiar-entity-type.v1.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/dto/cgiar-entity-type.v1.dto.ts
@@ -1,0 +1,5 @@
+export class CgiarEntityTypeDtoV1 {
+    code: string | number;
+    name: string;
+    portfolio: string;
+}

--- a/clarisa-back/src/api/cgiar-entity-type/dto/cgiar-entity-type.v1.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/dto/cgiar-entity-type.v1.dto.ts
@@ -1,5 +1,5 @@
 export class CgiarEntityTypeDtoV1 {
-    code: string | number;
-    name: string;
-    portfolio: string;
+  code: string | number;
+  name: string;
+  portfolio: string;
 }

--- a/clarisa-back/src/api/cgiar-entity-type/mappers/cgiar-entity-type.mapper.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/mappers/cgiar-entity-type.mapper.ts
@@ -82,14 +82,13 @@ export class CgiarEntityTypeMapper {
 
   public entityTypeListToDtoV1List(
     cgiarEntityTypes: CgiarEntityType[],
-    showIsActive: boolean = false,
   ): CgiarEntityTypeDtoV1[] {
     return cgiarEntityTypes.map((entity) => this.entityTypeToDtoV1(entity));
   }
 
   public entityTypeToDtoV1(entity: CgiarEntityType): CgiarEntityTypeDtoV1 {
     const dto = new CgiarEntityTypeDtoV1();
-    dto.code = entity.id; // o entity.code si existe
+    dto.code = entity.id;
     dto.name = entity.name;
     dto.portfolio = entity.portfolio_object?.name ?? '';
     return dto;

--- a/clarisa-back/src/api/cgiar-entity-type/mappers/cgiar-entity-type.mapper.ts
+++ b/clarisa-back/src/api/cgiar-entity-type/mappers/cgiar-entity-type.mapper.ts
@@ -5,6 +5,7 @@ import { BasicDtoMapper } from '../../../shared/mappers/basic-dto.mapper';
 import { CgiarEntityTypeDtoV2 } from '../dto/cgiar-entity-type.v2.dto';
 import { FundingSource } from '../../funding-source/entities/funding-source.entity';
 import { Portfolio } from '../../portfolio/entities/portfolio.entity';
+import { CgiarEntityTypeDtoV1 } from '../dto/cgiar-entity-type.v1.dto';
 
 @Injectable()
 export class CgiarEntityTypeMapper {
@@ -77,5 +78,20 @@ export class CgiarEntityTypeMapper {
     return cgiarEntityTypes.map((cgiarEntityType) =>
       this.classToDtoV2(cgiarEntityType, showIsActive),
     );
+  }
+
+  public entityTypeListToDtoV1List(
+    cgiarEntityTypes: CgiarEntityType[],
+    showIsActive: boolean = false,
+  ): CgiarEntityTypeDtoV1[] {
+    return cgiarEntityTypes.map((entity) => this.entityTypeToDtoV1(entity));
+  }
+
+  public entityTypeToDtoV1(entity: CgiarEntityType): CgiarEntityTypeDtoV1 {
+    const dto = new CgiarEntityTypeDtoV1();
+    dto.code = entity.id; // o entity.code si existe
+    dto.name = entity.name;
+    dto.portfolio = entity.portfolio_object?.name ?? '';
+    return dto;
   }
 }

--- a/clarisa-back/src/shared/entities/enums/cgiar-entity-types.ts
+++ b/clarisa-back/src/shared/entities/enums/cgiar-entity-types.ts
@@ -50,6 +50,22 @@ export class CgiarEntityTypeOption {
   public static readonly ONE_CGIAR_PLATFORM_KEY_MODULE =
     new CgiarEntityTypeOption(20, 'one-cgiar-pkfm');
   public static readonly OFFI = new CgiarEntityTypeOption(21, 'offices');
+  public static readonly SCIENCE_PROGRAM = new CgiarEntityTypeOption(
+    22,
+    'science-programs',
+  );
+  public static readonly SCALING_PROGRAM = new CgiarEntityTypeOption(
+    23,
+    'scaling-programs',
+  );
+  public static readonly ACCELERATOR = new CgiarEntityTypeOption(
+    24,
+    'accelerators',
+  );
+  public static readonly KEY_AREA_OF_WORK = new CgiarEntityTypeOption(
+    26,
+    'key-areas-of-work',
+  );
 
   private constructor(
     public readonly entity_type_id: number,


### PR DESCRIPTION
This pull request updates the structure and logic for handling CGIAR entity types in the backend. The main changes include introducing a new DTO for version 1 of the CGIAR entity type, updating the service and mapper to use this DTO, and expanding the supported entity type options. Additionally, a database migration updates the JSON structure for a specific endpoint to include the new `portfolio` field.

**Backend API and Data Model Updates:**

* Added new entity type options: `SCIENCE_PROGRAM`, `SCALING_PROGRAM`, `ACCELERATOR`, and `KEY_AREA_OF_WORK` to the `CgiarEntityTypeOption` enum, allowing these types to be handled throughout the application. [[1]](diffhunk://#diff-6fd0e049f6174eefb7447b14ef4248cc88b53529aa336513cffc0b4ee22f270aR53-R68) [[2]](diffhunk://#diff-2ee8345371f131618aae6a687988c575e1cc39b990316bc743b9fbc674ca8120R34-R37)

**DTO and Mapper Enhancements:**

* Introduced the `CgiarEntityTypeDtoV1` class with `code`, `name`, and `portfolio` fields for improved data transfer in version 1 endpoints. [[1]](diffhunk://#diff-7df187f3d5b502cdafa4bb7d4e932e408e75a73484d1053a436ccaaf0d81a24fR1-R5) [[2]](diffhunk://#diff-2ee8345371f131618aae6a687988c575e1cc39b990316bc743b9fbc674ca8120R10)
* Updated `CgiarEntityTypeMapper` with methods to map entity types to the new V1 DTO, including logic to extract the portfolio name. [[1]](diffhunk://#diff-b3ea33b0e1606551903c231b2a77a678f67ddf42ce2f02b05a0f9517c4cbc5bbR8) [[2]](diffhunk://#diff-b3ea33b0e1606551903c231b2a77a678f67ddf42ce2f02b05a0f9517c4cbc5bbR82-R95)

**Service Logic Improvements:**

* Modified the `findAllV1` method in `CgiarEntityTypeService` to use the new V1 DTO, include related portfolio objects in queries, and simplify the logic for filtering by active status.

**Database Migration:**

* Added a migration to update the `response_json` structure in the `hp_clarisa_endpoints` table (for `id = 2`), adding the `portfolio` field to the JSON schema.