### PR TITLE
* Feat Added Lineage for Global Units

### DIFF
--- a/clarisa-back/migrations/1758728616259-AddYearandLineageGlobalUnits.ts
+++ b/clarisa-back/migrations/1758728616259-AddYearandLineageGlobalUnits.ts
@@ -4,7 +4,7 @@ export class AddYearandLineageGlobalUnits1758728616259 implements MigrationInter
     name = 'AddYearandLineageGlobalUnits1758728616259'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE \`global_unit_lineage\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`from_global_unit_id\` bigint NOT NULL, \`to_global_unit_id\` bigint NOT NULL, \`relation_type\` enum ('MERGE', 'SPLIT', 'SUCCESSOR', 'RENAME') NOT NULL, \`note\` text NULL, \`created_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, \`updated_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`global_unit_lineage\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`from_global_unit_id\` bigint NULL, \`to_global_unit_id\` bigint NOT NULL, \`relation_type\` enum ('MERGE', 'SPLIT', 'SUCCESSOR', 'NEW') NOT NULL, \`note\` text NULL, \`created_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, \`updated_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
         await queryRunner.query(`ALTER TABLE \`global_units\` ADD \`year\` int NULL`);
         await queryRunner.query(`ALTER TABLE \`global_unit_lineage\` ADD CONSTRAINT \`FK_2ed43246e6d44248c37191ef4b2\` FOREIGN KEY (\`from_global_unit_id\`) REFERENCES \`global_units\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE \`global_unit_lineage\` ADD CONSTRAINT \`FK_ec1abd75ef70a979872f01cf31d\` FOREIGN KEY (\`to_global_unit_id\`) REFERENCES \`global_units\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);

--- a/clarisa-back/migrations/1758728616259-AddYearandLineageGlobalUnits.ts
+++ b/clarisa-back/migrations/1758728616259-AddYearandLineageGlobalUnits.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddYearandLineageGlobalUnits1758728616259 implements MigrationInterface {
+    name = 'AddYearandLineageGlobalUnits1758728616259'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`global_unit_lineage\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`from_global_unit_id\` bigint NOT NULL, \`to_global_unit_id\` bigint NOT NULL, \`relation_type\` enum ('MERGE', 'SPLIT', 'SUCCESSOR', 'RENAME') NOT NULL, \`note\` text NULL, \`created_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP, \`updated_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`global_units\` ADD \`year\` int NULL`);
+        await queryRunner.query(`ALTER TABLE \`global_unit_lineage\` ADD CONSTRAINT \`FK_2ed43246e6d44248c37191ef4b2\` FOREIGN KEY (\`from_global_unit_id\`) REFERENCES \`global_units\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`global_unit_lineage\` ADD CONSTRAINT \`FK_ec1abd75ef70a979872f01cf31d\` FOREIGN KEY (\`to_global_unit_id\`) REFERENCES \`global_units\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`global_unit_lineage\` DROP FOREIGN KEY \`FK_ec1abd75ef70a979872f01cf31d\``);
+        await queryRunner.query(`ALTER TABLE \`global_unit_lineage\` DROP FOREIGN KEY \`FK_2ed43246e6d44248c37191ef4b2\``);
+        await queryRunner.query(`ALTER TABLE \`global_units\` DROP COLUMN \`year\``);
+        await queryRunner.query(`DROP TABLE \`global_unit_lineage\``);
+    }
+
+}

--- a/clarisa-back/src/api/cgiar-entity/cgiar-entity.module.ts
+++ b/clarisa-back/src/api/cgiar-entity/cgiar-entity.module.ts
@@ -9,6 +9,7 @@ import { CenterRepository } from '../center/repositories/center.repository';
 import { CenterService } from '../center/center.service';
 import { CgiarEntityTypeRepository } from '../cgiar-entity-type/repositories/cgiar-entity-type.repository';
 import { CenterMapper } from '../center/mappers/center.mapper';
+import { GlobalUnitLineageRepository } from './repositories/global-unit-lineage.repository';
 
 @Module({
   controllers: [CgiarEntityController],
@@ -22,6 +23,7 @@ import { CenterMapper } from '../center/mappers/center.mapper';
     CenterRepository,
     CenterMapper,
     CenterService,
+    GlobalUnitLineageRepository,
   ],
 })
 export class CgiarEntityModule {}

--- a/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
+++ b/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
@@ -158,8 +158,7 @@ export class CgiarEntityService {
     const levelFilter = [1, 2];
     qb.andWhere('gu.level IN (:...levels)', { levels: levelFilter });
 
-    const portfolioFilter =
-      filters?.portfolioId !== undefined ? filters.portfolioId : 3;
+    const portfolioFilter = filters?.portfolioId ?? 3;
     qb.andWhere('gu.portfolio_id = :portfolioId', {
       portfolioId: portfolioFilter,
     });

--- a/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
+++ b/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { FindManyOptions, FindOptionsOrder, In } from 'typeorm';
 import { CgiarEntityTypeOption } from '../../shared/entities/enums/cgiar-entity-types';
 import { FindAllOptions } from '../../shared/entities/enums/find-all-options';
@@ -13,9 +9,6 @@ import { CgiarEntityDtoV1 } from './dto/cgiar-entity.v1.dto';
 import { CgiarEntityDtoV2 } from './dto/cgiar-entity.v2.dto';
 import { CenterService } from '../center/center.service';
 import { CenterDtoV1 } from '../center/dto/center.v1.dto';
-import { CgiarEntityTypeRepository } from '../cgiar-entity-type/repositories/cgiar-entity-type.repository';
-
-type VersionedGlobalUnitSlug = 'aows' | 'sps';
 
 @Injectable()
 export class CgiarEntityService {
@@ -31,28 +24,15 @@ export class CgiarEntityService {
       cgiar_entity_type_object: true,
       portfolio_object: true,
       outgoing_lineages: {
-        to_global_unit: true,
+        to_global_unit: {
+          parent_object: true,
+        },
       },
       incoming_lineages: {
-        from_global_unit: true,
+        from_global_unit: {
+          parent_object: true,
+        },
       },
-    },
-  };
-
-  private readonly versionedSlugConfig: Record<
-    VersionedGlobalUnitSlug,
-    {
-      prefixes: string[];
-      names: string[];
-    }
-  > = {
-    aows: {
-      prefixes: ['AoW', 'AOW'],
-      names: ['Area of Work', 'Areas of Work'],
-    },
-    sps: {
-      prefixes: ['SP'],
-      names: ['Strategic Program', 'Strategic Programme', 'Strategic Programs'],
     },
   };
 
@@ -60,7 +40,6 @@ export class CgiarEntityService {
     private readonly _cgiarEntityRepository: CgiarEntityRepository,
     private readonly _centerService: CenterService,
     private readonly _cgiarEntityMapper: CgiarEntityMapper,
-    private readonly _cgiarEntityTypeRepository: CgiarEntityTypeRepository,
   ) {}
 
   async findAllV1(
@@ -135,35 +114,94 @@ export class CgiarEntityService {
 
   async findAllV2(
     option: FindAllOptions = FindAllOptions.SHOW_ONLY_ACTIVE,
+    filters?: { type?: string; portfolioId?: number; year?: number },
   ): Promise<CgiarEntityDtoV2[]> {
-    let cgiarEntities: CgiarEntity[] = [];
+    const qb = this._cgiarEntityRepository
+      .createQueryBuilder('gu')
+      .leftJoinAndSelect('gu.parent_object', 'parent')
+      .leftJoinAndSelect('gu.cgiar_entity_type_object', 'type')
+      .leftJoinAndSelect('gu.portfolio_object', 'portfolio')
+      .leftJoinAndSelect('gu.outgoing_lineages', 'outgoing_lineage')
+      .leftJoinAndSelect(
+        'outgoing_lineage.to_global_unit',
+        'outgoing_lineage_to',
+      )
+      .leftJoinAndSelect(
+        'outgoing_lineage_to.parent_object',
+        'outgoing_lineage_to_parent',
+      )
+      .leftJoinAndSelect('gu.incoming_lineages', 'incoming_lineage')
+      .leftJoinAndSelect(
+        'incoming_lineage.from_global_unit',
+        'incoming_lineage_from',
+      )
+      .leftJoinAndSelect(
+        'incoming_lineage_from.parent_object',
+        'incoming_lineage_from_parent',
+      );
+
     let showIsActive = true;
     switch (option) {
       case FindAllOptions.SHOW_ALL:
-        cgiarEntities = await this._cgiarEntityRepository.find(
-          this._findOptionsV2,
-        );
         break;
       case FindAllOptions.SHOW_ONLY_ACTIVE:
       case FindAllOptions.SHOW_ONLY_INACTIVE:
         showIsActive = option !== FindAllOptions.SHOW_ONLY_ACTIVE;
-        cgiarEntities = await this._cgiarEntityRepository.find({
-          relations: this._findOptionsV2.relations,
-          where: {
-            auditableFields: {
-              is_active: option === FindAllOptions.SHOW_ONLY_ACTIVE,
-            },
-          },
+        qb.andWhere('gu.is_active = :isActive', {
+          isActive: option === FindAllOptions.SHOW_ONLY_ACTIVE,
         });
         break;
       default:
         throw Error('?!');
     }
 
+    const levelFilter = [1, 2];
+    qb.andWhere('gu.level IN (:...levels)', { levels: levelFilter });
+
+    const portfolioFilter =
+      filters?.portfolioId !== undefined ? filters.portfolioId : 3;
+    qb.andWhere('gu.portfolio_id = :portfolioId', {
+      portfolioId: portfolioFilter,
+    });
+
+    const typeId = this.resolveTypeFilter(filters?.type);
+    if (typeId) {
+      qb.andWhere('gu.global_unit_type_id = :typeId', { typeId });
+    }
+
+    if (filters?.year !== undefined && filters.year !== null) {
+      qb.andWhere('gu.year = :year', { year: filters.year });
+    }
+
+    qb.orderBy('gu.id', 'ASC');
+
+    const entities = await qb.getMany();
+
     return this._cgiarEntityMapper.classListToDtoV2List(
-      cgiarEntities,
+      entities,
       showIsActive,
+      false,
     );
+  }
+
+  private resolveTypeFilter(type?: string): number | undefined {
+    if (!type) {
+      return undefined;
+    }
+
+    const trimmed = type.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+
+    const option = CgiarEntityTypeOption.getfromPath(trimmed.toLowerCase());
+
+    return option?.entity_type_id;
   }
 
   async findOneV2(id: number): Promise<CgiarEntityDtoV2> {
@@ -210,154 +248,8 @@ export class CgiarEntityService {
     return this._cgiarEntityMapper.classListToDtoV2List(
       cgiarEntities,
       showIsActive,
+      true,
     );
-  }
-
-  async findAoWsByYear(
-    year: number,
-    options?: { latest?: boolean },
-  ): Promise<{ items: CgiarEntityDtoV2[]; latestYear?: number }> {
-    return this.findVersionedEntitiesBySlug('aows', year, options);
-  }
-
-  async findStrategicProgramsByYear(
-    year: number,
-    options?: { latest?: boolean },
-  ): Promise<{ items: CgiarEntityDtoV2[]; latestYear?: number }> {
-    return this.findVersionedEntitiesBySlug('sps', year, options);
-  }
-
-  private ensureValidYear(year: number): void {
-    if (!Number.isInteger(year) || year < 1900 || year > 9999) {
-      throw new BadRequestException('Year must be a valid four-digit number');
-    }
-  }
-
-  private async resolveVersionedTypeIds(
-    slug: VersionedGlobalUnitSlug,
-  ): Promise<number[]> {
-    const config = this.versionedSlugConfig[slug];
-    const staticOption = CgiarEntityTypeOption.getfromPath(slug);
-
-    const candidateIds = new Set<number>();
-
-    if (staticOption) {
-      candidateIds.add(staticOption.entity_type_id);
-    }
-
-    if (config) {
-      const prefixes = Array.from(
-        new Set((config.prefixes || []).map((prefix) => prefix.toLowerCase())),
-      );
-      const names = Array.from(
-        new Set((config.names || []).map((name) => name.toLowerCase())),
-      );
-
-      if (prefixes.length || names.length) {
-        const qb = this._cgiarEntityTypeRepository
-          .createQueryBuilder('gut')
-          .where('0 = 1');
-
-        if (prefixes.length) {
-          qb.orWhere('LOWER(gut.prefix) IN (:...prefixes)', { prefixes });
-        }
-
-        if (names.length) {
-          qb.orWhere('LOWER(gut.name) IN (:...names)', { names });
-        }
-
-        const matches = await qb.getMany();
-        matches.forEach((match) => candidateIds.add(match.id));
-      }
-    }
-
-    return Array.from(candidateIds);
-  }
-
-  private async findVersionedEntitiesBySlug(
-    slug: VersionedGlobalUnitSlug,
-    year: number,
-    options?: { latest?: boolean },
-  ): Promise<{ items: CgiarEntityDtoV2[]; latestYear?: number }> {
-    if (year === undefined || year === null) {
-      throw new BadRequestException(
-        'Year is required for versioned global units',
-      );
-    }
-
-    this.ensureValidYear(year);
-
-    const typeIds = await this.resolveVersionedTypeIds(slug);
-
-    if (!typeIds.length) {
-      throw new NotFoundException(
-        `Global unit types for slug "${slug}" are not configured`,
-      );
-    }
-
-    const latest = options?.latest ?? false;
-
-    const qb = this._cgiarEntityRepository
-      .createQueryBuilder('gu')
-      .leftJoinAndSelect('gu.parent_object', 'parent')
-      .leftJoinAndSelect('gu.cgiar_entity_type_object', 'type')
-      .leftJoinAndSelect('gu.portfolio_object', 'portfolio')
-      .leftJoinAndSelect('gu.outgoing_lineages', 'outgoing_lineage')
-      .leftJoinAndSelect(
-        'outgoing_lineage.to_global_unit',
-        'outgoing_lineage_to',
-      )
-      .leftJoinAndSelect('gu.incoming_lineages', 'incoming_lineage')
-      .leftJoinAndSelect(
-        'incoming_lineage.from_global_unit',
-        'incoming_lineage_from',
-      )
-      .where('gu.global_unit_type_id IN (:...typeIds)', { typeIds })
-      .andWhere('gu.is_active = :isActive', { isActive: true })
-      .orderBy('gu.smo_code', 'ASC');
-
-    if (latest) {
-      const latestPerCodeSubQuery = qb
-        .subQuery()
-        .select('latest.smo_code', 'smo_code')
-        .addSelect('MAX(latest.year)', 'max_year')
-        .from(CgiarEntity, 'latest')
-        .where('latest.global_unit_type_id IN (:...typeIds)')
-        .andWhere('latest.year IS NOT NULL')
-        .andWhere('latest.is_active = :isActive')
-        .groupBy('latest.smo_code')
-        .getQuery();
-
-      qb.innerJoin(
-        latestPerCodeSubQuery,
-        'latest_per_code',
-        'latest_per_code.smo_code = gu.smo_code AND latest_per_code.max_year = gu.year',
-      )
-        .andWhere('gu.year IS NOT NULL')
-        .addOrderBy('gu.year', 'DESC');
-
-      const entities = await qb.getMany();
-      const items = this._cgiarEntityMapper.classListToDtoV2List(entities);
-
-      const latestYear = entities.reduce<number | undefined>((acc, entity) => {
-        if (entity.year === null || entity.year === undefined) {
-          return acc;
-        }
-        if (acc === undefined || entity.year > acc) {
-          return entity.year;
-        }
-        return acc;
-      }, undefined);
-
-      return { items, latestYear };
-    }
-
-    qb.andWhere('gu.year = :year', { year }).addOrderBy('gu.name', 'ASC');
-
-    const entities = await qb.getMany();
-    const items = this._cgiarEntityMapper.classListToDtoV2List(entities);
-
-    return { items };
   }
 
   async getGlobalUnitsHierarchy(): Promise<any[]> {

--- a/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v1.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v1.dto.ts
@@ -5,4 +5,5 @@ export class CgiarEntityDtoV1 extends BasicDto {
   financial_code: string;
   institutionId: number;
   cgiarEntityTypeDTO: BasicDto;
+  year?: number;
 }

--- a/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts
@@ -1,4 +1,5 @@
 import { BasicDto } from '../../../shared/entities/dtos/basic-dto';
+import { GlobalUnitLineageDto } from './global-unit-lineage.dto';
 
 export class CgiarEntityDtoV2 extends BasicDto {
   id: number;
@@ -10,4 +11,7 @@ export class CgiarEntityDtoV2 extends BasicDto {
   start_date: string;
   end_date: string;
   level: number;
+  year?: number;
+  incoming_lineages?: GlobalUnitLineageDto[];
+  outgoing_lineages?: GlobalUnitLineageDto[];
 }

--- a/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts
@@ -2,16 +2,17 @@ import { BasicDto } from '../../../shared/entities/dtos/basic-dto';
 import { GlobalUnitLineageDto } from './global-unit-lineage.dto';
 
 export class CgiarEntityDtoV2 extends BasicDto {
-  id: number;
+  id?: number;
   short_name: string;
   acronym: string;
+  compose_code?: string;
+  year?: number;
   entity_type: BasicDto;
   parent: BasicDto;
   portfolio: BasicDto;
   start_date: string;
   end_date: string;
   level: number;
-  year?: number;
   incoming_lineages?: GlobalUnitLineageDto[];
   outgoing_lineages?: GlobalUnitLineageDto[];
 }

--- a/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts
@@ -15,4 +15,5 @@ export class CgiarEntityDtoV2 extends BasicDto {
   level: number;
   incoming_lineages?: GlobalUnitLineageDto[];
   outgoing_lineages?: GlobalUnitLineageDto[];
+  is_active?: boolean;
 }

--- a/clarisa-back/src/api/cgiar-entity/dto/global-unit-lineage.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity/dto/global-unit-lineage.dto.ts
@@ -1,12 +1,15 @@
-import { BasicDto } from '../../../shared/entities/dtos/basic-dto';
 import { GlobalUnitLineageRelationType } from '../entities/global-unit-lineage.entity';
 
+export class GlobalUnitLineageUnitDto {
+  code?: string;
+  name?: string;
+  compose_code?: string;
+  year?: number;
+}
+
 export class GlobalUnitLineageDto {
-  id: number;
   relation_type: GlobalUnitLineageRelationType;
   note?: string;
-  from_global_unit_id: number;
-  to_global_unit_id: number;
-  from?: BasicDto;
-  to?: BasicDto;
+  from_global_unit_id?: GlobalUnitLineageUnitDto;
+  to_global_unit_id?: GlobalUnitLineageUnitDto;
 }

--- a/clarisa-back/src/api/cgiar-entity/dto/global-unit-lineage.dto.ts
+++ b/clarisa-back/src/api/cgiar-entity/dto/global-unit-lineage.dto.ts
@@ -1,0 +1,12 @@
+import { BasicDto } from '../../../shared/entities/dtos/basic-dto';
+import { GlobalUnitLineageRelationType } from '../entities/global-unit-lineage.entity';
+
+export class GlobalUnitLineageDto {
+  id: number;
+  relation_type: GlobalUnitLineageRelationType;
+  note?: string;
+  from_global_unit_id: number;
+  to_global_unit_id: number;
+  from?: BasicDto;
+  to?: BasicDto;
+}

--- a/clarisa-back/src/api/cgiar-entity/entities/cgiar-entity.entity.ts
+++ b/clarisa-back/src/api/cgiar-entity/entities/cgiar-entity.entity.ts
@@ -11,6 +11,7 @@ import { AuditableEntity } from '../../../shared/entities/extends/auditable-enti
 import { CgiarEntityType } from '../../cgiar-entity-type/entities/cgiar-entity-type.entity';
 import { Institution } from '../../institution/entities/institution.entity';
 import { Portfolio } from '../../portfolio/entities/portfolio.entity';
+import { GlobalUnitLineage } from './global-unit-lineage.entity';
 
 @Entity('global_units')
 export class CgiarEntity {
@@ -31,6 +32,9 @@ export class CgiarEntity {
 
   @Column({ type: 'text', nullable: true })
   financial_code: string;
+
+  @Column({ type: 'int', nullable: true })
+  year: number;
 
   @Column({ type: 'timestamp', nullable: true })
   start_date: Date;
@@ -75,6 +79,12 @@ export class CgiarEntity {
   @ManyToOne(() => Portfolio, (p) => p.cgiar_entity_array)
   @JoinColumn({ name: 'portfolio_id' })
   portfolio_object: Portfolio;
+
+  @OneToMany(() => GlobalUnitLineage, (lineage) => lineage.from_global_unit)
+  outgoing_lineages: GlobalUnitLineage[];
+
+  @OneToMany(() => GlobalUnitLineage, (lineage) => lineage.to_global_unit)
+  incoming_lineages: GlobalUnitLineage[];
 
   //auditable fields
 

--- a/clarisa-back/src/api/cgiar-entity/entities/global-unit-lineage.entity.ts
+++ b/clarisa-back/src/api/cgiar-entity/entities/global-unit-lineage.entity.ts
@@ -11,7 +11,7 @@ export enum GlobalUnitLineageRelationType {
   MERGE = 'MERGE',
   SPLIT = 'SPLIT',
   SUCCESSOR = 'SUCCESSOR',
-  RENAME = 'RENAME',
+  RENAME = 'NEW',
 }
 
 @Entity('global_unit_lineage')
@@ -19,7 +19,7 @@ export class GlobalUnitLineage {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ type: 'bigint', nullable: false })
+  @Column({ type: 'bigint', nullable: true })
   from_global_unit_id: number;
 
   @Column({ type: 'bigint', nullable: false })

--- a/clarisa-back/src/api/cgiar-entity/entities/global-unit-lineage.entity.ts
+++ b/clarisa-back/src/api/cgiar-entity/entities/global-unit-lineage.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { CgiarEntity } from './cgiar-entity.entity';
+
+export enum GlobalUnitLineageRelationType {
+  MERGE = 'MERGE',
+  SPLIT = 'SPLIT',
+  SUCCESSOR = 'SUCCESSOR',
+  RENAME = 'RENAME',
+}
+
+@Entity('global_unit_lineage')
+export class GlobalUnitLineage {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ type: 'bigint', nullable: false })
+  from_global_unit_id: number;
+
+  @Column({ type: 'bigint', nullable: false })
+  to_global_unit_id: number;
+
+  @Column({
+    type: 'enum',
+    enum: GlobalUnitLineageRelationType,
+    nullable: false,
+  })
+  relation_type: GlobalUnitLineageRelationType;
+
+  @Column({ type: 'text', nullable: true })
+  note: string;
+
+  @Column({
+    type: 'datetime',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  created_at: Date;
+
+  @Column({
+    type: 'datetime',
+    default: () => 'CURRENT_TIMESTAMP',
+    onUpdate: 'CURRENT_TIMESTAMP',
+  })
+  updated_at: Date;
+
+  @ManyToOne(() => CgiarEntity, (entity) => entity.outgoing_lineages, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'from_global_unit_id' })
+  from_global_unit: CgiarEntity;
+
+  @ManyToOne(() => CgiarEntity, (entity) => entity.incoming_lineages, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'to_global_unit_id' })
+  to_global_unit: CgiarEntity;
+}

--- a/clarisa-back/src/api/cgiar-entity/mappers/cgiar-entity.mapper.ts
+++ b/clarisa-back/src/api/cgiar-entity/mappers/cgiar-entity.mapper.ts
@@ -151,6 +151,7 @@ export class CgiarEntityMapper {
       ? DateTime.fromJSDate(cgiarEntity.end_date).toFormat('yyyy-MM-dd')
       : null;
     cgiarEntityDtoV2.level = cgiarEntity.level;
+    cgiarEntityDtoV2.is_active = cgiarEntity.auditableFields?.is_active;
 
     if (cgiarEntity.cgiar_entity_type_object) {
       cgiarEntityDtoV2.entity_type = this._cgiarEntityTypeMapper.classToDtoV1(

--- a/clarisa-back/src/api/cgiar-entity/repositories/global-unit-lineage.repository.ts
+++ b/clarisa-back/src/api/cgiar-entity/repositories/global-unit-lineage.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { GlobalUnitLineage } from '../entities/global-unit-lineage.entity';
+
+@Injectable()
+export class GlobalUnitLineageRepository extends Repository<GlobalUnitLineage> {
+  constructor(private readonly dataSource: DataSource) {
+    super(GlobalUnitLineage, dataSource.createEntityManager());
+  }
+}

--- a/clarisa-back/src/api/project/project.controller.ts
+++ b/clarisa-back/src/api/project/project.controller.ts
@@ -1,7 +1,5 @@
 import {
   Controller,
-  Get,
-  Param,
   UseInterceptors,
   ClassSerializerInterceptor,
 } from '@nestjs/common';
@@ -11,14 +9,4 @@ import { ProjectService } from './project.service';
 @UseInterceptors(ClassSerializerInterceptor)
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}
-
-  @Get()
-  async findAll() {
-    return this.projectService.findAll();
-  }
-
-  @Get('by-global-unit/:officialCode')
-  async findByGlobalUnit(@Param('officialCode') officialCode: string) {
-    return this.projectService.findByGlobalUnit(officialCode);
-  }
 }

--- a/clarisa-back/src/shared/entities/enums/cgiar-entity-types.ts
+++ b/clarisa-back/src/shared/entities/enums/cgiar-entity-types.ts
@@ -50,6 +50,22 @@ export class CgiarEntityTypeOption {
   public static readonly ONE_CGIAR_PLATFORM_KEY_MODULE =
     new CgiarEntityTypeOption(20, 'one-cgiar-pkfm');
   public static readonly OFFI = new CgiarEntityTypeOption(21, 'offices');
+  public static readonly SCIENCE_PROGRAM = new CgiarEntityTypeOption(
+    22,
+    'science-programs',
+  );
+  public static readonly SCALING_PROGRAM = new CgiarEntityTypeOption(
+    23,
+    'scaling-programs',
+  );
+  public static readonly ACCELERATOR = new CgiarEntityTypeOption(
+    24,
+    'accelerators',
+  );
+  public static readonly KEY_AREA_OF_WORK = new CgiarEntityTypeOption(
+    26,
+    'key-areas-of-work',
+  );
 
   private constructor(
     public readonly entity_type_id: number,


### PR DESCRIPTION
This pull request introduces lineage tracking and filtering capabilities for global units, along with improvements to the data model and API responses. The main changes include adding a new `global_unit_lineage` table, updating the `CgiarEntity` entity and DTOs to support lineage and year fields, and enhancing the API to allow filtering by type, portfolio, and year. These changes improve the ability to track historical relationships between global units and enable more flexible querying.

### Database and Entity Model Enhancements

* Added a new `global_unit_lineage` table and entity to track relationships (merge, split, successor, new) between global units, including foreign key constraints and necessary fields. (`clarisa-back/migrations/1758728616259-AddYearandLineageGlobalUnits.ts`, `clarisa-back/src/api/cgiar-entity/entities/global-unit-lineage.entity.ts`) [[1]](diffhunk://#diff-e54836f6fc6a49140141790c62c596c4017f9c517facd4217833f6cdec6b29adR1-R20) [[2]](diffhunk://#diff-0b31c0ce53e67ef694cec90b7a4788b0b57b22cf9d528b7d4fd05c52b2f514e7R1-R62)
* Updated the `CgiarEntity` entity to include a new `year` column and relationships for outgoing and incoming lineages, enabling linkage to the new lineage table. (`clarisa-back/src/api/cgiar-entity/entities/cgiar-entity.entity.ts`) [[1]](diffhunk://#diff-0a9f99873a643e256852f20245cd09d32a026cfb5eeb963676e44bc8398ab4bcR37-R39) [[2]](diffhunk://#diff-0a9f99873a643e256852f20245cd09d32a026cfb5eeb963676e44bc8398ab4bcR84-R89)

### API and DTO Improvements

* Enhanced the `CgiarEntityDtoV2` and related DTOs to include lineage data (`incoming_lineages`, `outgoing_lineages`), `year`, and a composed code for better representation in API responses. (`clarisa-back/src/api/cgiar-entity/dto/cgiar-entity.v2.dto.ts`, `clarisa-back/src/api/cgiar-entity/dto/global-unit-lineage.dto.ts`) [[1]](diffhunk://#diff-6ff5324feac204d0a84e8ace5e666a68065c8bb89d9db70eb8d24fe5e96e7f83R2-R18) [[2]](diffhunk://#diff-bd3841feeb69b38446f8186cb903b73ffeb44fd4093fb6fceb08e3a01ea3cf67R1-R15)
* Updated the controller and service to support filtering by type, portfolioId, and year, and to include lineage information in the returned data. (`clarisa-back/src/api/cgiar-entity/cgiar-entity.controller.ts`, `clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts`) [[1]](diffhunk://#diff-112369d62b354e11aeb5629d9d4a3b7eabe0bd00bf345fc9e20384cc2cd2d3f6L36-R46) [[2]](diffhunk://#diff-112369d62b354e11aeb5629d9d4a3b7eabe0bd00bf345fc9e20384cc2cd2d3f6R78-R85) [[3]](diffhunk://#diff-d4e6ed9f30662770d68c90c548e00db0af6a9c4c4f1c0a268d33596f57dc07cfR117-R206)

### Mapper and Module Changes

* Refactored the mapper to build composed codes and lineage DTOs, and to support conditional inclusion of IDs and lineage data in DTOs. Registered the new lineage repository in the module. (`clarisa-back/src/api/cgiar-entity/mappers/cgiar-entity.mapper.ts`, `clarisa-back/src/api/cgiar-entity/cgiar-entity.module.ts`) [[1]](diffhunk://#diff-28c529f00730cfd94ecc4b06eeef3b284511c6d9a1975cabecc7b56ceb02985fR30-R80) [[2]](diffhunk://#diff-28c529f00730cfd94ecc4b06eeef3b284511c6d9a1975cabecc7b56ceb02985fR136-R144) [[3]](diffhunk://#diff-28c529f00730cfd94ecc4b06eeef3b284511c6d9a1975cabecc7b56ceb02985fR176-R197) [[4]](diffhunk://#diff-aded499fd56869658bdbafbbdf17ea29f0f75eab6465c227423b8b35b64890b9R12) [[5]](diffhunk://#diff-aded499fd56869658bdbafbbdf17ea29f0f75eab6465c227423b8b35b64890b9R26)

These changes collectively enable tracking and querying of global unit relationships and improve the expressiveness and flexibility of the API.