### PR TITLE
* Feat Apply current year filter to CGIAR entity queries

### DIFF
--- a/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
+++ b/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
@@ -168,9 +168,11 @@ export class CgiarEntityService {
       qb.andWhere('gu.global_unit_type_id = :typeId', { typeId });
     }
 
-    if (filters?.year !== undefined && filters.year !== null) {
-      qb.andWhere('gu.year = :year', { year: filters.year });
-    }
+    const yearFilter =
+      filters?.year !== undefined && filters?.year !== null
+        ? filters.year
+        : new Date().getFullYear();
+    qb.andWhere('gu.year = :year', { year: yearFilter });
 
     qb.orderBy('gu.id', 'ASC');
 
@@ -218,12 +220,17 @@ export class CgiarEntityService {
   ): Promise<CgiarEntityDtoV2[]> {
     let cgiarEntities: CgiarEntity[] = [];
     let showIsActive = true;
+    const yearFilter = new Date().getFullYear();
 
     switch (option) {
       case FindAllOptions.SHOW_ALL:
         cgiarEntities = await this._cgiarEntityRepository.find({
           relations: this._findOptionsV2.relations,
-          where: { portfolio_object: In([portfolioId]), level: 1 },
+          where: {
+            portfolio_object: In([portfolioId]),
+            level: 1,
+            year: yearFilter,
+          },
         });
         break;
       case FindAllOptions.SHOW_ONLY_ACTIVE:
@@ -234,6 +241,7 @@ export class CgiarEntityService {
           where: {
             portfolio_object: In([portfolioId]),
             level: 1,
+            year: yearFilter,
             auditableFields: {
               is_active: option === FindAllOptions.SHOW_ONLY_ACTIVE,
             },
@@ -252,8 +260,9 @@ export class CgiarEntityService {
   }
 
   async getGlobalUnitsHierarchy(): Promise<any[]> {
+    const currentYear = new Date().getFullYear();
     const parents = await this._cgiarEntityRepository.find({
-      where: { level: 1 },
+      where: { level: 1, year: currentYear },
       relations: [
         'portfolio_object',
         'cgiar_entity_type_object',

--- a/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
+++ b/clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts
@@ -168,10 +168,7 @@ export class CgiarEntityService {
       qb.andWhere('gu.global_unit_type_id = :typeId', { typeId });
     }
 
-    const yearFilter =
-      filters?.year !== undefined && filters?.year !== null
-        ? filters.year
-        : new Date().getFullYear();
+    const yearFilter = filters?.year ?? new Date().getFullYear();
     qb.andWhere('gu.year = :year', { year: yearFilter });
 
     qb.orderBy('gu.id', 'ASC');


### PR DESCRIPTION
This pull request updates how the year filter is applied throughout the `CgiarEntityService` in `clarisa-back/src/api/cgiar-entity/cgiar-entity.service.ts`. The main change is to consistently default the year filter to the current year when it is not explicitly provided, ensuring that queries always target entities from the current year unless specified otherwise.

**Year filtering improvements:**

* The year filter in the main query builder now defaults to the current year if not provided in `filters`, ensuring consistent behavior across queries.
* The `findAllV2` method applies the current year as a default filter for both `SHOW_ALL` and `SHOW_ONLY_ACTIVE` options, so only entities from the current year are returned unless another year is specified. [[1]](diffhunk://#diff-d4e6ed9f30662770d68c90c548e00db0af6a9c4c4f1c0a268d33596f57dc07cfR223-R233) [[2]](diffhunk://#diff-d4e6ed9f30662770d68c90c548e00db0af6a9c4c4f1c0a268d33596f57dc07cfR244)
* The `getGlobalUnitsHierarchy` method now includes a filter for the current year when fetching parent entities, aligning it with the new default year filtering logic.