### PR TITLE
* Feat Added Bilateral Project Endpoints

### DIFF
--- a/clarisa-back/src/api/project/project.controller.ts
+++ b/clarisa-back/src/api/project/project.controller.ts
@@ -2,6 +2,8 @@ import {
   Controller,
   UseInterceptors,
   ClassSerializerInterceptor,
+  Get,
+  Param,
 } from '@nestjs/common';
 import { ProjectService } from './project.service';
 
@@ -9,4 +11,14 @@ import { ProjectService } from './project.service';
 @UseInterceptors(ClassSerializerInterceptor)
 export class ProjectController {
   constructor(private readonly projectService: ProjectService) {}
+
+  @Get()
+  async findAll() {
+    return this.projectService.findAll();
+  }
+
+  @Get('by-global-unit/:officialCode')
+  async findByGlobalUnit(@Param('officialCode') officialCode: string) {
+    return this.projectService.findByGlobalUnit(officialCode);
+  }
 }

--- a/toc-integration/src/entities/tocWorkPackages.ts
+++ b/toc-integration/src/entities/tocWorkPackages.ts
@@ -32,4 +32,7 @@ export class TocWorkPackages {
   @Index()
   @Column({ name: "initiativeId", type: "varchar", length: 50, nullable: true })
   initiativeId: string | null;
+
+  @Column({ name: "year", type: "int", nullable: true })
+  year: number | null;
 }

--- a/toc-integration/src/services/ToCWorkPackages.ts
+++ b/toc-integration/src/services/ToCWorkPackages.ts
@@ -54,6 +54,10 @@ export class ToCWorkPackagesService {
           typeof ost?.initiativeId === "number"
             ? String(ost.initiativeId)
             : null,
+        year:
+          typeof ost?.year === "string" || typeof ost?.year === "number"
+            ? Number(ost.year)
+            : null,
       };
 
       let existing =


### PR DESCRIPTION
This pull request introduces new API endpoints to the `ProjectController` and adds support for a `year` field in the `TocWorkPackages` entity and its related service logic. These changes improve both the API's capabilities and the data model for work packages.

### API enhancements
* Added `findAll` and `findByGlobalUnit` GET endpoints to `ProjectController`, allowing retrieval of all projects and projects filtered by global unit via `officialCode`. (`clarisa-back/src/api/project/project.controller.ts`)

### Data model and service updates
* Added a nullable integer `year` column to the `TocWorkPackages` entity for tracking the year associated with each work package. (`toc-integration/src/entities/tocWorkPackages.ts`)
* Updated the `ToCWorkPackagesService` to correctly map and convert the new `year` field when handling work package data. (`toc-integration/src/services/ToCWorkPackages.ts`)