### PR TITLE
* Feat updated target saving

### DIFF
--- a/toc-integration/src/services/TocResultServices.ts
+++ b/toc-integration/src/services/TocResultServices.ts
@@ -1175,7 +1175,7 @@ export class TocResultServices {
         if (saved && targetData != null) {
           await this.saveIndicatorTargetV2(
             saved.id,
-            saved.toc_result_indicator_id,
+            saved.related_node_id,
             targetData
           );
         }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the `TocResultServices` class in `toc-integration/src/services/TocResultServices.ts`. The main focus is on refining how records are queried, updated, and deleted based on `related_node_id` and indicator IDs, resulting in more predictable and robust database operations.

**Database query and update logic improvements:**

* Refined the logic for updating or inserting `TocResults` records: now queries and updates use only `related_node_id` instead of a composite key, ensuring that records are managed exclusively by this identifier.
* After saving or updating a `TocResults` record, the related indicator targets are now saved using `related_node_id` instead of `toc_result_indicator_id`, ensuring correct linkage.

**Indicator and target management enhancements:**

* When deactivating indicators, the code now also deactivates any indicators linked by `toc_result_id_toc` if `related_node_id` is present, improving consistency in indicator status updates.
* Before inserting new indicator targets, the code now deletes any existing targets for both `id_indicator` and `toc_result_indicator_id`, preventing duplication and ensuring data integrity. Informational logs are added for these deletions.