### PR TITLE
✨ Add migration to update innovation type name for clarity

### DIFF
--- a/clarisa-back/migrations/1761848757540-UpdateValueOtherClarisaInnovType.ts
+++ b/clarisa-back/migrations/1761848757540-UpdateValueOtherClarisaInnovType.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateValueOtherClarisaInnovType1761848757540 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE \`innovation_types\`
+            SET \`name\` = 'Other/I’m not sure/This typology does not work for my innovation'
+            WHERE \`id\` = 15;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE \`innovation_types\`
+            SET \`name\` = 'Other'
+            WHERE \`id\` = 15;
+        `);
+    }
+
+}


### PR DESCRIPTION
This pull request adds a new migration to update the name of a specific innovation type in the database. The migration ensures that the innovation type with `id` 15 is renamed to provide more descriptive text, and also allows for reverting the change if needed.

**Database migration:**

* Added migration `1761848757540-UpdateValueOtherClarisaInnovType.ts` to update the `name` field of the `innovation_types` table for `id` 15 to 'Other/I’m not sure/This typology does not work for my innovation'.
* Provided a down method to revert the `name` field for `id` 15 back to 'Other'.