### PR TITLE
✨ Add migration to update innovation type name for clarity

### DIFF
--- a/clarisa-back/migrations/1761848757540-UpdateValueOtherClarisaInnovType.ts
+++ b/clarisa-back/migrations/1761848757540-UpdateValueOtherClarisaInnovType.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateValueOtherClarisaInnovType1761848757540 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE \`innovation_types\`
+            SET \`name\` = 'Other/I’m not sure/This typology does not work for my innovation'
+            WHERE \`id\` = 15;
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE \`innovation_types\`
+            SET \`name\` = 'Other'
+            WHERE \`id\` = 15;
+        `);
+    }
+
+}


### PR DESCRIPTION
This pull request adds a new migration to update the name of an innovation type in the database. The migration changes the name for the entry with `id = 15` and provides a way to revert the change if needed.

Database migration:

* Added `1761848757540-UpdateValueOtherClarisaInnovType.ts` to update the `name` of the `innovation_types` entry with `id = 15` from 'Other' to 'Other/I’m not sure/This typology does not work for my innovation', with a corresponding rollback in the `down` method.