### PR TITLE
* Feat Add target-center entity and update target logic

### DIFF
--- a/toc-integration/src/entities/tocIndicatorTarget.ts
+++ b/toc-integration/src/entities/tocIndicatorTarget.ts
@@ -4,16 +4,22 @@ import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from "typeorm";
 export class TocResultIndicatorTarget {
   @PrimaryGeneratedColumn()
   toc_result_indicator_id: string;
-  @Column()
-  target_value: number;
-  @Column()
-  target_date: string;
+
+  @Column({ nullable: true })
+  target_value: number | null;
+
+  @Column({ nullable: true })
+  target_date: string | null;
+
   @Column()
   number_target: number;
+
   @Column()
   id_indicator: number;
-  @Column()
-  project_id: number;
-  @Column()
-  center_id: number;
+
+  @Column({ nullable: true })
+  project_id: number | null;
+
+  @Column({ nullable: true })
+  center_id: number | null;
 }

--- a/toc-integration/src/entities/tocResultIndicatorTargetCenter.ts
+++ b/toc-integration/src/entities/tocResultIndicatorTargetCenter.ts
@@ -1,0 +1,28 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { TocResultIndicatorTarget } from "./tocIndicatorTarget";
+
+@Entity("toc_result_indicator_target_center")
+export class TocResultIndicatorTargetCenter {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  toc_indicator_target_id: string;
+
+  @Column()
+  center_id: number;
+
+  @ManyToOne(
+    () => TocResultIndicatorTarget,
+    (target) => target.toc_result_indicator_id,
+    { onDelete: "CASCADE" }
+  )
+  @JoinColumn({ name: "toc_indicator_target_id" })
+  target: TocResultIndicatorTarget;
+}

--- a/toc-integration/src/services/TocResultServices.ts
+++ b/toc-integration/src/services/TocResultServices.ts
@@ -1442,7 +1442,7 @@ export class TocResultServices {
             for (const centerId of centersForRow) {
               centerRows.push(
                 targetCenterRepo.create({
-                  toc_indicator_target_id: saved.toc_result_indicator_id as any,
+                  toc_indicator_target_id: saved.toc_result_indicator_id,
                   center_id: centerId,
                 })
               );

--- a/toc-integration/src/services/TocResultServices.ts
+++ b/toc-integration/src/services/TocResultServices.ts
@@ -20,6 +20,7 @@ import { TocResultIndicatorRegionDto } from "../dto/tocIndicatorRegion";
 import { TocResultIndicatorCountryDto } from "../dto/tocIndicatorCountry";
 import { TocResultIndicatorTargetDTO } from "../dto/tocIndicatorTarget";
 import { TocResultIndicatorTarget } from "../entities/tocIndicatorTarget";
+import { TocResultIndicatorTargetCenter } from "../entities/tocResultIndicatorTargetCenter";
 import { TocResultProject } from "../entities/tocResultsProjects";
 import { TocResultPartners } from "../entities/tocResultsPartners";
 import { TocSdgResults } from "../entities/tocSdgResults";
@@ -1282,6 +1283,9 @@ export class TocResultServices {
     try {
       const dataSource: DataSource = await Database.getDataSource();
       const repo = dataSource.getRepository(TocResultIndicatorTarget);
+      const targetCenterRepo = dataSource.getRepository(
+        TocResultIndicatorTargetCenter
+      );
 
       if (!id_indicator || !toc_result_indicator_id) return true;
 
@@ -1295,6 +1299,10 @@ export class TocResultServices {
         where: { id_indicator },
       });
 
+      const existingByTocResultIndicatorId = await repo.find({
+        where: { toc_result_indicator_id },
+      });
+
       if (existingByIdIndicator.length > 0) {
         console.info({
           message: "Deleting existing targets by id_indicator",
@@ -1303,10 +1311,6 @@ export class TocResultServices {
         });
         await repo.delete({ id_indicator });
       }
-
-      const existingByTocResultIndicatorId = await repo.find({
-        where: { toc_result_indicator_id },
-      });
 
       if (existingByTocResultIndicatorId.length > 0) {
         console.info({
@@ -1346,59 +1350,49 @@ export class TocResultServices {
           return null;
         };
 
+        const centerIds: number[] = Array.from(
+          new Set<number>(
+            centers
+              .map((center) =>
+                parseNumeric(center?.code ?? center?.center_id ?? center?.id)
+              )
+              .filter((id): id is number => id != null)
+          )
+        );
+        const projectIds: number[] = Array.from(
+          new Set<number>(
+            projects
+              .map((project) =>
+                parseNumeric(
+                  project?.code ?? project?.project_id ?? project?.id
+                )
+              )
+              .filter((id): id is number => id != null)
+          )
+        );
+
         const rowsToInsert: Partial<TocResultIndicatorTarget>[] = [];
-        let insertedFromCollections = false;
-
-        const pushRowsForCollection = (
-          ids: any[],
-          idExtractor: (item: any) => number | null,
-          assign: (
-            row: Partial<TocResultIndicatorTarget>,
-            id: number | null
-          ) => void
-        ) => {
-          if (!ids.length) return;
-          for (const item of ids) {
-            const numericId = idExtractor(item);
-            if (numericId == null) continue;
-            insertedFromCollections = true;
-
-            for (const [year, value] of yearEntries) {
-              const row = repo.create({
-                id_indicator,
-                toc_result_indicator_id,
-                number_target: number++,
-                target_value: parseValue(value),
-                target_date: String(year),
-                center_id: null,
-                project_id: null,
-              });
-              assign(row, numericId);
-              rowsToInsert.push(row);
-            }
-          }
-        };
+        const centersPerRow: number[][] = [];
 
         if (yearEntries.length) {
-          pushRowsForCollection(
-            centers,
-            (center) =>
-              parseNumeric(center?.code ?? center?.center_id ?? center?.id),
-            (row, id) => {
-              row.center_id = id;
+          if (projectIds.length) {
+            for (const projectId of projectIds) {
+              for (const [year, value] of yearEntries) {
+                rowsToInsert.push(
+                  repo.create({
+                    id_indicator,
+                    toc_result_indicator_id,
+                    number_target: number++,
+                    target_value: parseValue(value),
+                    target_date: String(year),
+                    center_id: null,
+                    project_id: projectId,
+                  })
+                );
+                centersPerRow.push(centerIds);
+              }
             }
-          );
-
-          pushRowsForCollection(
-            projects,
-            (project) =>
-              parseNumeric(project?.code ?? project?.project_id ?? project?.id),
-            (row, id) => {
-              row.project_id = id;
-            }
-          );
-
-          if (!insertedFromCollections) {
+          } else {
             for (const [year, value] of yearEntries) {
               rowsToInsert.push(
                 repo.create({
@@ -1411,6 +1405,7 @@ export class TocResultServices {
                   project_id: null,
                 })
               );
+              centersPerRow.push(centerIds);
             }
           }
         } else {
@@ -1434,10 +1429,29 @@ export class TocResultServices {
             project_id: null,
           });
           rowsToInsert.push(row);
+          centersPerRow.push(centerIds);
         }
 
         if (rowsToInsert.length) {
-          await repo.insert(rowsToInsert);
+          const savedTargets = await repo.save(rowsToInsert);
+          const centerRows: TocResultIndicatorTargetCenter[] = [];
+          savedTargets.forEach((saved, idx) => {
+            const centersForRow = centersPerRow[idx];
+            if (!centersForRow?.length) return;
+
+            for (const centerId of centersForRow) {
+              centerRows.push(
+                targetCenterRepo.create({
+                  toc_indicator_target_id: saved.toc_result_indicator_id as any,
+                  center_id: centerId,
+                })
+              );
+            }
+          });
+
+          if (centerRows.length) {
+            await targetCenterRepo.save(centerRows);
+          }
         }
       }
 


### PR DESCRIPTION
This pull request introduces significant improvements to how target indicators and their associations with centers and projects are managed in the codebase. The main changes include making several fields nullable in the `TocResultIndicatorTarget` entity, introducing a new entity to handle many-to-many relationships between targets and centers, and updating service logic to correctly handle these associations during insert operations.

**Entity and Database Model Changes:**

* Made `target_value`, `target_date`, `project_id`, and `center_id` fields nullable in the `TocResultIndicatorTarget` entity to better support cases where these values may not be present.
* Added a new entity `TocResultIndicatorTargetCenter` to represent the many-to-many relationship between indicator targets and centers, including the necessary foreign key and cascade delete logic.

**Service Logic Updates:**

* Updated the service to use the new `TocResultIndicatorTargetCenter` entity and repository, enabling the association of multiple centers with a single target indicator. [[1]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40R23) [[2]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40R1286-R1288)
* Refactored the logic for inserting target rows: now, for each target row, all relevant center associations are captured and inserted into the new join table, ensuring data integrity and proper linkage. [[1]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40R1353-R1395) [[2]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40R1408) [[3]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40R1432-R1454)
* Improved the deletion and replacement logic to ensure old associations are cleaned up before new ones are inserted, preventing duplicate or stale data. [[1]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40R1302-R1305) [[2]](diffhunk://#diff-49bb2ed3d24a3dd611a7887ebe3bca75afb3a030e11bf41be60fb5bc80563e40L1307-L1310)