### PR TITLE
🐛 Move Power BI URL from hardcoded template to environment variable

### DIFF
--- a/clarisa-front/src/app/landing-page/pages/institutions-request-bi/sections/iframe-institution/iframe-institution.component.html
+++ b/clarisa-front/src/app/landing-page/pages/institutions-request-bi/sections/iframe-institution/iframe-institution.component.html
@@ -1,3 +1,3 @@
 <div class="iframe_container">
-    <iframe title="CLARISA institution requests" src="https://app.powerbi.com/view?r=eyJrIjoiMDY4YWMyNDQtYmViMy00YTlhLWE1ODYtMTlhYjI2MjlmYTYyIiwidCI6IjZhZmEwZTAwLWZhMTQtNDBiNy04YTJlLTIyYTdmOGMzNTdkNSIsImMiOjh9&pageName=ReportSection" frameborder="0" allowFullScreen="true"></iframe>
+    <iframe title="CLARISA institution requests" [src]="powerBiUrl" frameborder="0" allowFullScreen="true"></iframe>
   </div>

--- a/clarisa-front/src/app/landing-page/pages/institutions-request-bi/sections/iframe-institution/iframe-institution.component.ts
+++ b/clarisa-front/src/app/landing-page/pages/institutions-request-bi/sections/iframe-institution/iframe-institution.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-iframe-institution',
@@ -6,7 +8,11 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./iframe-institution.component.scss'],
 })
 export class IframeInstituionComponent implements OnInit {
-  constructor() {}
+  powerBiUrl: SafeResourceUrl;
 
-  ngOnInit(): void {}
+  constructor(private sanitizer: DomSanitizer) {}
+
+  ngOnInit(): void {
+    this.powerBiUrl = this.sanitizer.bypassSecurityTrustResourceUrl(environment.powerBiInstitutionRequestUrl);
+  }
 }


### PR DESCRIPTION
## Summary

- **Moved the Power BI embed URL** for the Partner Requests dashboard from a hardcoded value in the HTML template to an environment variable (`environment.powerBiInstitutionRequestUrl`)
- **Used Angular's `DomSanitizer`** (`bypassSecurityTrustResourceUrl`) to safely bind the URL via `[src]` property binding instead of a static `src` attribute
- This makes it easy to update the Power BI link per environment (dev, staging, prod) without changing the source code

## Files changed

| File | Change |
|------|--------|
| `iframe-institution.component.html` | Replaced hardcoded `src` with `[src]="powerBiUrl"` binding |
| `iframe-institution.component.ts` | Added `DomSanitizer` + `environment` imports, initialized `powerBiUrl` from env variable in `ngOnInit` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)