### PR TITLE
* Feat Support year filter & phase resolution for ToC results

### DIFF
--- a/toc-integration/docs/toc-results-api.md
+++ b/toc-integration/docs/toc-results-api.md
@@ -38,7 +38,28 @@ Returns a list of active ToC results matching the specified category and initiat
 
 | Parameter | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| `phase` | `string` | No | Filters results by a specific ToC Phase UUID (e.g., `99134294-d7a1-4966-a63e-227c9e29b9fb`). |
+| `year` | `number` | No | Reporting year (e.g. `2025`, `2026`). **Default: `2025`**. Resolves the ToC phase UUID automatically. |
+| `phase` | `string` | No | ToC Phase UUID (legacy). If both `year` and `phase` are sent, they must refer to the same reporting year. |
+
+**Examples:**
+
+```
+GET .../toc/results/category/OUTPUT/initiative/SP09
+GET .../toc/results/category/OUTPUT/initiative/SP09?year=2026
+GET .../toc/results/category/EOI/initiative/SP09?year=2026
+```
+
+**Response envelope:**
+
+```json
+{
+  "meta": {
+    "year": 2026,
+    "phase": "7baf200a-c958-4ded-9894-6557a94cae18"
+  },
+  "response": [ "... results ..." ]
+}
+```
 
 ---
 

--- a/toc-integration/src/controllers/tocControllerResult.ts
+++ b/toc-integration/src/controllers/tocControllerResult.ts
@@ -1,6 +1,10 @@
 import axios from "axios";
 import { Request, Response } from "express";
 import { TocServicesResults } from "../services/TocServicesResult";
+import {
+  DEFAULT_REPORTING_YEAR,
+  parseReportingYearInput,
+} from "../types/sp-sync-meta";
 
 export class tocController {
   async getTocResultDashboard(req: Request, res: Response) {
@@ -90,7 +94,7 @@ export class tocController {
 
   async getTocResultsByCategoryAndCode(req: Request, res: Response) {
     const { category, official_code } = req.params;
-    const { phase } = req.query;
+    const { phase, year } = req.query;
 
     if (!category || !official_code) {
       return res.status(400).json({
@@ -99,19 +103,37 @@ export class tocController {
       });
     }
 
+    const parsedYear =
+      year === undefined
+        ? DEFAULT_REPORTING_YEAR
+        : parseReportingYearInput(year);
+
+    if (year !== undefined && parsedYear == null) {
+      return res.status(400).json({
+        message: "Query parameter 'year' must be a valid reporting year.",
+        statusCode: 400
+      });
+    }
+
     try {
       let servicesInformation = new TocServicesResults();
-      const data = await servicesInformation.getTocResultsByCategoryAndCode(
-        category,
-        official_code,
-        typeof phase === "string" ? phase : undefined
-      );
-      return res.json({ response: data });
-    } catch (error) {
+      const { meta, results } =
+        await servicesInformation.getTocResultsByCategoryAndCode(
+          category,
+          official_code,
+          {
+            year: parsedYear ?? DEFAULT_REPORTING_YEAR,
+            phaseId: typeof phase === "string" ? phase : undefined,
+          }
+        );
+      return res.json({ meta, response: results });
+    } catch (error: any) {
       console.error(error);
-      return res.status(500).json({
+      const statusCode =
+        typeof error?.statusCode === "number" ? error.statusCode : 500;
+      return res.status(statusCode).json({
         message: error.message || "An error occurred while fetching ToC results.",
-        statusCode: 500
+        statusCode
       });
     }
   }

--- a/toc-integration/src/services/TocServicesResult.ts
+++ b/toc-integration/src/services/TocServicesResult.ts
@@ -14,7 +14,25 @@ import { TocOutputOutcomeRelationService } from "./TocOutputOutcomeRelations";
 import { sendSlackNotification } from "../validators/slackNotification";
 import { ToCWorkPackagesService } from "./ToCWorkPackages";
 import { env } from "process";
-import { resolvePhaseId, SpSyncMeta } from "../types/sp-sync-meta";
+import {
+  DEFAULT_REPORTING_YEAR,
+  resolvePhaseId,
+  resolvePhaseIdFromReportingYear,
+  SpSyncMeta,
+} from "../types/sp-sync-meta";
+
+export interface TocResultsReadFilters {
+  year?: number;
+  phaseId?: string;
+}
+
+export interface TocResultsReadMeta {
+  year: number;
+  phase: string;
+}
+
+const PHASES_LIST_CACHE_TTL_MS = 10 * 60 * 1000;
+let phasesListCache: { body: unknown; fetchedAt: number } | null = null;
 
 export class TocServicesResults {
   public validatorType = new ValidatorTypes();
@@ -319,12 +337,54 @@ export class TocServicesResults {
     }
   }
 
+  private async fetchPhasesListBody(forceRefresh = false): Promise<unknown> {
+    const now = Date.now();
+    if (
+      !forceRefresh &&
+      phasesListCache &&
+      now - phasesListCache.fetchedAt < PHASES_LIST_CACHE_TTL_MS
+    ) {
+      return phasesListCache.body;
+    }
+
+    const listUrl = `${env.LINK_TOC}/api/phases`;
+    const { data: listBody } = await axios.get(listUrl, { timeout: 10000 });
+    phasesListCache = { body: listBody, fetchedAt: now };
+    return listBody;
+  }
+
+  private listPhasesFromResponse(
+    body: unknown
+  ): { id?: string; reporting_year?: unknown }[] {
+    if (!body || typeof body !== "object") {
+      return [];
+    }
+
+    const record = body as Record<string, unknown>;
+    if (Array.isArray(record.data)) {
+      return record.data.filter(
+        (item): item is { id?: string; reporting_year?: unknown } =>
+          !!item && typeof item === "object"
+      );
+    }
+
+    if (Array.isArray(body)) {
+      return body.filter(
+        (item): item is { id?: string; reporting_year?: unknown } =>
+          !!item && typeof item === "object"
+      );
+    }
+
+    if (typeof record.id === "string") {
+      return [record as { id?: string; reporting_year?: unknown }];
+    }
+
+    return [];
+  }
+
   private async fetchReportingYear(phaseId: string): Promise<number | null> {
     try {
-      // ToC GET /api/phases/{id} ignores the path id and returns the active phase.
-      // Always resolve reporting_year from the full list and match by phase id.
-      const listUrl = `${env.LINK_TOC}/api/phases`;
-      const { data: listBody } = await axios.get(listUrl, { timeout: 10000 });
+      const listBody = await this.fetchPhasesListBody();
       const phase = this.findPhaseInPhasesResponse(listBody, phaseId);
       if (phase) {
         return this.parseReportingYear(phase.reporting_year);
@@ -343,6 +403,81 @@ export class TocServicesResults {
       });
       return null;
     }
+  }
+
+  private async fetchPhaseIdByReportingYear(
+    reportingYear: number
+  ): Promise<string | null> {
+    try {
+      const listBody = await this.fetchPhasesListBody();
+      for (const phase of this.listPhasesFromResponse(listBody)) {
+        if (
+          typeof phase.id === "string" &&
+          this.parseReportingYear(phase.reporting_year) === reportingYear
+        ) {
+          return phase.id;
+        }
+      }
+    } catch (error) {
+      console.warn({
+        message: "Could not resolve phase id from ToC phases API",
+        reportingYear,
+        error,
+      });
+    }
+
+    return resolvePhaseIdFromReportingYear(reportingYear);
+  }
+
+  private createReadFilterError(
+    message: string,
+    statusCode: number
+  ): Error & { statusCode: number } {
+    const error = new Error(message) as Error & { statusCode: number };
+    error.statusCode = statusCode;
+    return error;
+  }
+
+  async resolveReadFilters(
+    filters: TocResultsReadFilters = {}
+  ): Promise<TocResultsReadMeta> {
+    const reportingYear = filters.year ?? DEFAULT_REPORTING_YEAR;
+    const explicitPhaseId =
+      typeof filters.phaseId === "string" ? filters.phaseId.trim() : "";
+
+    if (explicitPhaseId) {
+      const yearFromPhase = await this.fetchReportingYear(explicitPhaseId);
+      const resolvedYear = yearFromPhase ?? reportingYear;
+
+      if (
+        filters.year != null &&
+        yearFromPhase != null &&
+        filters.year !== yearFromPhase
+      ) {
+        throw this.createReadFilterError(
+          `Query parameters 'year' (${filters.year}) and 'phase' (${explicitPhaseId}) refer to different reporting years (${yearFromPhase}).`,
+          400
+        );
+      }
+
+      return {
+        year: resolvedYear,
+        phase: explicitPhaseId,
+      };
+    }
+
+    const phaseId = await this.fetchPhaseIdByReportingYear(reportingYear);
+    if (!phaseId) {
+      throw this.createReadFilterError(
+        `No ToC phase found for reporting year ${reportingYear}.`,
+        404
+      );
+    }
+
+    return {
+      year: reportingYear,
+      phase: phaseId,
+    };
   }
 
   private findPhaseInPhasesResponse(
@@ -518,18 +653,17 @@ export class TocServicesResults {
     let sdgRepo = dataSource.getRepository(TocSdgResults);
   }
 
-  async getTocResultsByCategoryAndCode(category: string, officialCode: string, phaseId?: string) {
+  async getTocResultsByCategoryAndCode(
+    category: string,
+    officialCode: string,
+    filters: TocResultsReadFilters = {}
+  ): Promise<{ meta: TocResultsReadMeta; results: any[] }> {
+    const readMeta = await this.resolveReadFilters(filters);
     const dataSource: DataSource = await Database.getDataSource();
     const queryRunner = dataSource.createQueryRunner();
     await queryRunner.connect();
 
     try {
-      let reportingYear: number | null = null;
-      if (phaseId) {
-        reportingYear = await this.fetchReportingYear(phaseId);
-      }
-      const workPackageYear = reportingYear ?? 2025;
-
       let queryResults = `
         SELECT DISTINCT
           tr.id AS id,
@@ -548,20 +682,21 @@ export class TocServicesResults {
         WHERE tr.is_active = 1
           AND tr.category = ?
           AND tr.official_code = ?
+          AND tr.phase = ?
       `;
-      const paramsResults: any[] = [workPackageYear, category.toUpperCase(), officialCode];
-      
-      if (phaseId) {
-        queryResults += ` AND tr.phase = ?`;
-        paramsResults.push(phaseId);
-      }
+      const paramsResults: any[] = [
+        readMeta.year,
+        category.toUpperCase(),
+        officialCode,
+        readMeta.phase,
+      ];
 
       queryResults += ` ORDER BY wp.acronym, tr.result_title ASC`;
 
       const results = await queryRunner.query(queryResults, paramsResults);
 
       if (!results || !results.length) {
-        return [];
+        return { meta: readMeta, results: [] };
       }
 
       const tocResultIds = results.map((r: any) => r.id);
@@ -644,7 +779,7 @@ export class TocServicesResults {
         };
       });
 
-      return enrichedResults;
+      return { meta: readMeta, results: enrichedResults };
     } finally {
       await queryRunner.release();
     }

--- a/toc-integration/src/types/sp-sync-meta.ts
+++ b/toc-integration/src/types/sp-sync-meta.ts
@@ -9,6 +9,13 @@ export interface SpSyncMeta {
 }
 
 export const TOC_PHASE_2025_ID = "99134294-d7a1-4966-a63e-227c9e29b9fb";
+export const TOC_PHASE_2026_ID = "7baf200a-c958-4ded-9894-6557a94cae18";
+export const DEFAULT_REPORTING_YEAR = 2025;
+
+export const PHASE_ID_BY_REPORTING_YEAR: Record<number, string> = {
+  2025: TOC_PHASE_2025_ID,
+  2026: TOC_PHASE_2026_ID,
+};
 
 export function resolvePhaseId(inputPhaseId?: string | null): string {
   const trimmed = typeof inputPhaseId === "string" ? inputPhaseId.trim() : "";
@@ -22,4 +29,21 @@ export function resolvePhaseId(inputPhaseId?: string | null): string {
   }
 
   return TOC_PHASE_2025_ID;
+}
+
+export function parseReportingYearInput(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+export function resolvePhaseIdFromReportingYear(year: number): string | null {
+  return PHASE_ID_BY_REPORTING_YEAR[year] ?? null;
 }


### PR DESCRIPTION
Add reporting year support and phase resolution to ToC results endpoints. Docs updated with examples and response envelope. Controller now accepts and validates a `year` query param (defaults to DEFAULT_REPORTING_YEAR), returns structured { meta, response } and forwards proper status codes from service errors. Service changes: introduce read filter/meta interfaces, add cached phases list fetch (10min TTL), helpers to list/resolve phases, parse reporting year input, and resolve phase id from a year (with fallback mapping for known years). Query logic now enforces phase/year consistency, includes phase in SQL params, and returns meta along with enriched results. Also improve error creation/propagation and add constants for default phase IDs.