### PR TITLE
* Feat Enable hybrid authentication for partner requests

### DIFF
--- a/API-KEY-AUTH-STRATEGY.md
+++ b/API-KEY-AUTH-STRATEGY.md
@@ -785,13 +785,13 @@ All key lifecycle events are logged via the existing `AuditableEntity`:
 
 ### 11.3 Phase 3: Integration (Week 3)
 
-**P2-2994 phase A (in progress):** hybrid auth infrastructure only — guards implemented, **no production controllers wired yet**.
+**P2-2994 phase B (in progress):** hybrid auth wired on partner-request write endpoints. JWT panel users keep working; API-key callers need scope `partner-requests:create` and a body `userId` for audit fields.
 
 - [x] `CompositeAuthGuard` — `X-API-Key` or JWT (JWT unchanged when header absent)
 - [x] `HybridAuthorizationGuard` — API key → scope check via `ApiKeyGuard`; JWT → existing `PermissionGuard`
 - [x] `@GetApiKeyAuth()` request decorator
 - [x] Progressive rollout plan (see §11.3.1)
-- [ ] Wire hybrid guards on pilot endpoints (phase B — e.g. partner-request writes)
+- [x] Wire hybrid guards on pilot endpoints (phase B — partner-request writes)
 - [ ] Add `X-API-Key` header detection in existing middleware (if needed beyond guards)
 - [ ] Update microservice configurations to use API keys
 - [ ] Create migration script to generate API keys for existing AppSecret relationships
@@ -802,13 +802,13 @@ Do **not** enable API key auth on all endpoints at once. Existing JWT panel user
 
 | Phase | Scope | Endpoints | Notes |
 |-------|--------|-----------|--------|
-| **4.0** (current) | Infrastructure only | None | `CompositeAuthGuard`, `HybridAuthorizationGuard`, `@GetApiKeyAuth`, `@RequireApiKeyScope` — exported from `GuardsModule`; zero controller changes |
-| **4.1** | Pilot — partner-request **writes** | `POST create`, `PATCH update`, `POST respond`, `POST create-bulk` | Replace `@UseGuards(JwtAuthGuard, PermissionGuard)` with hybrid guards; add `@RequireApiKeyScope(...)` per handler; optional feature flag for TEST first |
+| **4.0** | Infrastructure only | None | `CompositeAuthGuard`, `HybridAuthorizationGuard`, `@GetApiKeyAuth`, `@RequireApiKeyScope` — exported from `GuardsModule` |
+| **4.1** (current) | Pilot — partner-request **writes** | `POST create`, `PATCH update`, `POST respond`, `POST create-bulk` | Hybrid guards + `@RequireApiKeyScope('partner-requests:create')`; API-key path uses body `userId` for audit; MIS can come from query or key `mis` |
 | **4.1** | Partner-request **reads** | `GET` routes | Stay **public** unless a future requirement mandates scoped reads |
 | **4.2+** | Additional modules | e.g. `institutions`, `toc` | One module at a time after pilot metrics |
 | **Excluded** | Admin / panel-only | `api-keys`, `users`, `roles`, permissions admin | **JWT only** — never API key |
 
-**Future controller pattern (partner-request write example — not applied in phase A):**
+**Controller pattern applied on partner-request writes:**
 
 ```typescript
 import { CompositeAuthGuard } from '../../shared/guards/composite-auth.guard';
@@ -820,12 +820,12 @@ import { GetApiKeyAuth } from '../../shared/decorators/get-api-key-auth.decorato
 @UseGuards(CompositeAuthGuard, HybridAuthorizationGuard)
 @RequireApiKeyScope('partner-requests:create')
 async createPartnerRequest(
-  @GetUserData() userData: UserData,
+  @GetUserData() userData: UserData | undefined,
   @GetApiKeyAuth() apiKeyAuth: ApiKeyAuthContext | undefined,
   @Body() dto: CreatePartnerRequestDto,
 ) {
   // JWT path: userData populated as today
-  // API-key path: apiKeyAuth.mis identifies the consumer; handler may branch if needed
+  // API-key path: body.userId required for audit; apiKeyAuth.mis can fill MIS
 }
 ```
 
@@ -839,7 +839,7 @@ Request
                            → HybridAuthorizationGuard → PermissionGuard (unchanged)
 ```
 
-Import `GuardsModule` in the feature module when wiring phase B.
+Import `GuardsModule` in the feature module when wiring hybrid endpoints (already done for `PartnerRequestModule`).
 
 ### 11.4 Phase 4: Observability & Dashboard (Week 4)
 

--- a/API-KEY-INTEGRATION-GUIDE.md
+++ b/API-KEY-INTEGRATION-GUIDE.md
@@ -385,7 +385,19 @@ Machine-to-machine consumers use `X-API-Key`. Human panel users continue using J
 
 ### 6.7 Current rollout status
 
-Hybrid infrastructure (`CompositeAuthGuard`, `HybridAuthorizationGuard`, `@RequireApiKeyScope`) is implemented. Endpoint-by-endpoint enablement is **progressive**. Before integrating a specific endpoint, confirm with the CLARISA team whether it already accepts `X-API-Key` or still requires JWT/AppSecret.
+Hybrid infrastructure is implemented. **Partner-request writes** already accept hybrid auth:
+
+| Endpoint | Auth |
+|----------|------|
+| `POST /api/partner-requests/create` | JWT **or** `X-API-Key` + scope `partner-requests:create` |
+| `PATCH /api/partner-requests/update` | JWT **or** `X-API-Key` + scope `partner-requests:create` |
+| `POST /api/partner-requests/respond` | JWT **or** `X-API-Key` + scope `partner-requests:create` |
+| `POST /api/partner-requests/create-bulk` | JWT **or** `X-API-Key` + scope `partner-requests:create` |
+| Partner-request `GET` routes | Still public |
+
+API-key callers must send a valid `userId` in the body (existing CLARISA user) because audit fields (`created_by` / `updated_by` / accept-reject actor) still reference `users.id`. JWT panel users continue unchanged.
+
+Other modules remain progressive — confirm with the CLARISA team before integrating.
 
 ---
 

--- a/clarisa-back/src/api/partner-request/partner-request.controller.spec.ts
+++ b/clarisa-back/src/api/partner-request/partner-request.controller.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PartnerRequestController } from './partner-request.controller';
 import { PartnerRequestService } from './partner-request.service';
-import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard';
-import { PermissionGuard } from '../../shared/guards/permission.guard';
+import { CompositeAuthGuard } from '../../shared/guards/composite-auth.guard';
+import { HybridAuthorizationGuard } from '../../shared/guards/hybrid-authorization.guard';
 
 describe('PartnerRequestController', () => {
   let controller: PartnerRequestController;
@@ -28,9 +28,9 @@ describe('PartnerRequestController', () => {
         { provide: PartnerRequestService, useValue: mockPartnerRequestService },
       ],
     })
-      .overrideGuard(JwtAuthGuard)
+      .overrideGuard(CompositeAuthGuard)
       .useValue(mockGuard)
-      .overrideGuard(PermissionGuard)
+      .overrideGuard(HybridAuthorizationGuard)
       .useValue(mockGuard)
       .compile();
 
@@ -78,15 +78,41 @@ describe('PartnerRequestController', () => {
     expect(mockPartnerRequestService.findOne).toHaveBeenCalledWith(1);
   });
 
-  it('should call service on createPartnerRequest', async () => {
+  it('should call service on createPartnerRequest with JWT actor', async () => {
     mockPartnerRequestService.createPartnerRequest.mockResolvedValue({ id: 1 });
     const userData = { userId: 1, email: 'test@test.com' } as any;
     const dto = {} as any;
 
-    await controller.createPartnerRequest(userData, dto, 'clarisa');
+    await controller.createPartnerRequest(userData, undefined, dto, 'clarisa');
     expect(mockPartnerRequestService.createPartnerRequest).toHaveBeenCalledWith(
       dto,
       { ...userData, mis: 'clarisa' },
+    );
+  });
+
+  it('should resolve API-key create using body userId and key MIS', async () => {
+    mockPartnerRequestService.createPartnerRequest.mockResolvedValue({ id: 1 });
+    const apiKeyAuth = {
+      api_key_id: 9,
+      key_prefix: 'cl_prod_abcdefgh',
+      mis: { id: 3, name: 'PRMS', acronym: 'PRMS' },
+    };
+    const dto = { userId: 42, externalUserMail: 'bot@example.com' } as any;
+
+    await controller.createPartnerRequest(
+      undefined,
+      apiKeyAuth,
+      dto,
+      undefined,
+    );
+    expect(mockPartnerRequestService.createPartnerRequest).toHaveBeenCalledWith(
+      dto,
+      {
+        userId: 42,
+        email: 'bot@example.com',
+        permissions: '',
+        mis: 'PRMS',
+      },
     );
   });
 
@@ -95,7 +121,7 @@ describe('PartnerRequestController', () => {
     const userData = { userId: 1, email: 'test@test.com' } as any;
     const dto = {} as any;
 
-    await controller.respondPartnerRequest(userData, dto);
+    await controller.respondPartnerRequest(userData, undefined, dto);
     expect(
       mockPartnerRequestService.respondPartnerRequest,
     ).toHaveBeenCalledWith(dto, userData);
@@ -106,7 +132,7 @@ describe('PartnerRequestController', () => {
     const userData = { userId: 1, email: 'test@test.com' } as any;
     const dto = {} as any;
 
-    await controller.updatePartnerRequest(userData, dto);
+    await controller.updatePartnerRequest(userData, undefined, dto);
     expect(mockPartnerRequestService.updatePartnerRequest).toHaveBeenCalledWith(
       dto,
       userData,

--- a/clarisa-back/src/api/partner-request/partner-request.controller.ts
+++ b/clarisa-back/src/api/partner-request/partner-request.controller.ts
@@ -12,17 +12,21 @@ import {
   Patch,
 } from '@nestjs/common';
 import { GetUserData } from '../../shared/decorators/user-data.decorator';
+import { GetApiKeyAuth } from '../../shared/decorators/get-api-key-auth.decorator';
+import { RequireApiKeyScope } from '../../shared/decorators/require-api-key-scope.decorator';
 import { RespondRequestDto } from '../../shared/entities/dtos/respond-request.dto';
 import { ResponseDto } from '../../shared/entities/dtos/response.dto';
-import { JwtAuthGuard } from '../../shared/guards/jwt-auth.guard';
-import { PermissionGuard } from '../../shared/guards/permission.guard';
+import { CompositeAuthGuard } from '../../shared/guards/composite-auth.guard';
+import { HybridAuthorizationGuard } from '../../shared/guards/hybrid-authorization.guard';
 import { UserData } from '../../shared/interfaces/user-data';
+import { ApiKeyAuthContext } from '../api-key/interfaces/api-key-auth-context';
 import { CreatePartnerRequestDto } from './dto/create-partner-request.dto';
 import { PartnerRequestDto } from './dto/partner-request.dto';
 import { UpdatePartnerRequestDto } from './dto/update-partner-request.dto';
 import { PartnerRequestService } from './partner-request.service';
 import { BulkPartnerRequestDto } from './dto/create-partner-dto';
 import { FindAllOptions } from 'src/shared/entities/enums/find-all-options';
+import { resolvePartnerRequestActor } from './utils/resolve-partner-request-actor';
 
 @Controller()
 @UseInterceptors(ClassSerializerInterceptor)
@@ -54,15 +58,22 @@ export class PartnerRequestController {
   }
 
   @Post('create')
-  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @UseGuards(CompositeAuthGuard, HybridAuthorizationGuard)
+  @RequireApiKeyScope('partner-requests:create')
   async createPartnerRequest(
-    @GetUserData() userData: UserData,
+    @GetUserData() userData: UserData | undefined,
+    @GetApiKeyAuth() apiKeyAuth: ApiKeyAuthContext | undefined,
     @Body() newPartnerRequest: CreatePartnerRequestDto,
     @Query('mis') mis: string,
   ): Promise<ResponseDto<PartnerRequestDto>> {
+    const actor = resolvePartnerRequestActor(userData, apiKeyAuth, {
+      userId: newPartnerRequest.userId,
+      email: newPartnerRequest.externalUserMail,
+    });
+
     const userDataMis: UserData & { mis: string } = {
-      ...userData,
-      mis,
+      ...actor,
+      mis: mis || apiKeyAuth?.mis?.acronym || '',
     };
 
     return this.partnerRequestService.createPartnerRequest(
@@ -72,34 +83,47 @@ export class PartnerRequestController {
   }
 
   @Post('respond')
-  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @UseGuards(CompositeAuthGuard, HybridAuthorizationGuard)
+  @RequireApiKeyScope('partner-requests:create')
   async respondPartnerRequest(
-    @GetUserData() userData: UserData,
+    @GetUserData() userData: UserData | undefined,
+    @GetApiKeyAuth() apiKeyAuth: ApiKeyAuthContext | undefined,
     @Body() respondPartnerRequestDto: RespondRequestDto,
   ): Promise<PartnerRequestDto> {
+    const actor = resolvePartnerRequestActor(userData, apiKeyAuth, {
+      userId: respondPartnerRequestDto.userId,
+      email: respondPartnerRequestDto.externalUserMail,
+    });
+
     return this.partnerRequestService.respondPartnerRequest(
       respondPartnerRequestDto,
-      userData,
+      actor,
     );
   }
 
   @Patch('update')
-  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @UseGuards(CompositeAuthGuard, HybridAuthorizationGuard)
+  @RequireApiKeyScope('partner-requests:create')
   async updatePartnerRequest(
-    @GetUserData() userData: UserData,
+    @GetUserData() userData: UserData | undefined,
+    @GetApiKeyAuth() apiKeyAuth: ApiKeyAuthContext | undefined,
     @Body() updatePartnerRequest: UpdatePartnerRequestDto,
   ): Promise<ResponseDto<PartnerRequestDto>> {
+    const actor = resolvePartnerRequestActor(userData, apiKeyAuth, {
+      userId: updatePartnerRequest.userId,
+      email: updatePartnerRequest.externalUserMail,
+    });
+
     return this.partnerRequestService.updatePartnerRequest(
       updatePartnerRequest,
-      userData,
+      actor,
     );
   }
 
   @Post('create-bulk')
-  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @UseGuards(CompositeAuthGuard, HybridAuthorizationGuard)
+  @RequireApiKeyScope('partner-requests:create')
   async createBulk(@Body() createBulkPartner: BulkPartnerRequestDto) {
-    const result: any =
-      await this.partnerRequestService.createBulk(createBulkPartner);
-    return result;
+    return this.partnerRequestService.createBulk(createBulkPartner);
   }
 }

--- a/clarisa-back/src/api/partner-request/partner-request.module.ts
+++ b/clarisa-back/src/api/partner-request/partner-request.module.ts
@@ -14,9 +14,15 @@ import { OpenSearchInstitutionApi } from '../../integration/opensearch/instituti
 import { MessagingMicroservice } from '../../integration/microservices/messaging/messaging.microservice';
 import { HandlebarsTemplateModule } from '../handlebars-template/handlebars-template.module';
 import { HandlebarsCompiler } from '../../shared/utils/handlebars-compiler';
+import { GuardsModule } from '../../shared/guards/guards.module';
 
 @Module({
-  imports: [OpenSearchModule, HttpModule, HandlebarsTemplateModule],
+  imports: [
+    OpenSearchModule,
+    HttpModule,
+    HandlebarsTemplateModule,
+    GuardsModule,
+  ],
   controllers: [PartnerRequestController],
   providers: [
     PartnerRequestService,

--- a/clarisa-back/src/api/partner-request/utils/resolve-partner-request-actor.spec.ts
+++ b/clarisa-back/src/api/partner-request/utils/resolve-partner-request-actor.spec.ts
@@ -1,0 +1,47 @@
+import { BadRequestException } from '@nestjs/common';
+import { resolvePartnerRequestActor } from './resolve-partner-request-actor';
+
+describe('resolvePartnerRequestActor', () => {
+  const jwtUser = {
+    userId: 10,
+    email: 'panel@cgiar.org',
+    permissions: 'admin',
+  };
+
+  const apiKeyAuth = {
+    api_key_id: 1,
+    key_prefix: 'cl_prod_abcdefgh',
+    mis: { id: 3, name: 'PRMS', acronym: 'PRMS' },
+  };
+
+  it('prefers JWT user when present', () => {
+    expect(
+      resolvePartnerRequestActor(jwtUser, apiKeyAuth, { userId: 99 }),
+    ).toEqual(jwtUser);
+  });
+
+  it('builds actor from body for API-key callers', () => {
+    expect(
+      resolvePartnerRequestActor(undefined, apiKeyAuth, {
+        userId: 42,
+        email: 'bot@example.com',
+      }),
+    ).toEqual({
+      userId: 42,
+      email: 'bot@example.com',
+      permissions: '',
+    });
+  });
+
+  it('requires body userId for API-key callers', () => {
+    expect(() => resolvePartnerRequestActor(undefined, apiKeyAuth, {})).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('fails when neither JWT nor API-key context exists', () => {
+    expect(() => resolvePartnerRequestActor(undefined, undefined)).toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/clarisa-back/src/api/partner-request/utils/resolve-partner-request-actor.ts
+++ b/clarisa-back/src/api/partner-request/utils/resolve-partner-request-actor.ts
@@ -1,0 +1,33 @@
+import { BadRequestException } from '@nestjs/common';
+import { ApiKeyAuthContext } from '../../api-key/interfaces/api-key-auth-context';
+import { UserData } from '../../../shared/interfaces/user-data';
+
+/**
+ * JWT callers: use panel user from the token.
+ * API-key callers: audit fields still require a real users.id — take it from the request body.
+ */
+export function resolvePartnerRequestActor(
+  userData: UserData | undefined,
+  apiKeyAuth: ApiKeyAuthContext | undefined,
+  bodyUser?: { userId?: number; email?: string },
+): UserData {
+  if (userData?.userId) {
+    return userData;
+  }
+
+  if (apiKeyAuth) {
+    if (!bodyUser?.userId || bodyUser.userId < 1) {
+      throw new BadRequestException(
+        'Body field userId is required when using X-API-Key authentication',
+      );
+    }
+
+    return {
+      userId: bodyUser.userId,
+      email: bodyUser.email ?? '',
+      permissions: '',
+    };
+  }
+
+  throw new BadRequestException('Authenticated user context is missing');
+}

--- a/clarisa-back/src/api/user/user.service.ts
+++ b/clarisa-back/src/api/user/user.service.ts
@@ -73,9 +73,11 @@ export class UserService {
    */
   async findOneByEmail(email: string, isService = true): Promise<User> {
     const user: User = await this.usersRepository.findOneBy({ email });
-    if (user) {
-      user.permissions = await this.getUserPermissions(user);
+    if (!user) {
+      return null;
     }
+
+    user.permissions = await this.getUserPermissions(user);
 
     if (isService) {
       delete user.password;
@@ -93,9 +95,11 @@ export class UserService {
    */
   async findOneByUsername(username: string, isService = false): Promise<User> {
     const user: User = await this.usersRepository.findOneBy({ username });
-    if (user) {
-      user.permissions = await this.getUserPermissions(user);
+    if (!user) {
+      return null;
     }
+
+    user.permissions = await this.getUserPermissions(user);
 
     if (isService) {
       delete user.password;

--- a/clarisa-back/src/shared/entities/dtos/final-response.dto.ts
+++ b/clarisa-back/src/shared/entities/dtos/final-response.dto.ts
@@ -39,4 +39,14 @@ export class FinalResponseDto<T> {
   public static getStatus(responseDto: FinalResponseDto<any>): HttpStatus {
     return responseDto.status;
   }
+
+  toJSON() {
+    return {
+      response: this.response,
+      message: this.message,
+      status: this.status,
+      date: this.date,
+      path: this.path,
+    };
+  }
 }

--- a/clarisa-back/src/shared/entities/dtos/response.dto.ts
+++ b/clarisa-back/src/shared/entities/dtos/response.dto.ts
@@ -66,4 +66,12 @@ export class ResponseDto<T> {
   ): ResponseDto<T> {
     return new ResponseDto(response, message, status);
   }
+
+  toJSON() {
+    return {
+      response: this.response,
+      message: this.message,
+      status: this.status,
+    };
+  }
 }

--- a/clarisa-back/src/shared/filters/exceptions.filter.ts
+++ b/clarisa-back/src/shared/filters/exceptions.filter.ts
@@ -1,22 +1,102 @@
-import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
+import {
+  Catch,
+  ArgumentsHost,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import { FinalResponseDto } from '../entities/dtos/final-response.dto';
+import { ResponseDto } from '../entities/dtos/response.dto';
 
 @Catch()
-export class ExceptionsFilter<T> implements ExceptionFilter {
+export class ExceptionsFilter implements ExceptionFilter {
   constructor(private readonly _httpAdapterHost: HttpAdapterHost) {}
 
-  catch(exception: FinalResponseDto<T>, host: ArgumentsHost): void {
-    // In certain situations `httpAdapter` might not be available in the
-    // constructor method, thus we should resolve it here.
+  catch(exception: unknown, host: ArgumentsHost): void {
     const { httpAdapter } = this._httpAdapterHost;
-
     const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+    const path = request?.url ?? request?.originalUrl ?? '';
+
+    if (this._isFinalResponseDto(exception)) {
+      httpAdapter.reply(
+        response,
+        exception,
+        FinalResponseDto.getStatus(exception),
+      );
+      return;
+    }
+
+    if (this._isResponseDto(exception)) {
+      httpAdapter.reply(
+        response,
+        FinalResponseDto.fromResponse(exception, path),
+        ResponseDto.getStatus(exception),
+      );
+      return;
+    }
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const exceptionResponse = exception.getResponse();
+      const payload =
+        typeof exceptionResponse === 'string'
+          ? { message: exceptionResponse }
+          : exceptionResponse;
+
+      httpAdapter.reply(
+        response,
+        FinalResponseDto.fromResponse(
+          ResponseDto.buildCustomResponse(payload, exception.message, status),
+          path,
+        ),
+        status,
+      );
+      return;
+    }
+
+    const message =
+      exception instanceof Error ? exception.message : 'Internal server error';
 
     httpAdapter.reply(
-      ctx.getResponse(),
-      exception,
-      FinalResponseDto.getStatus(exception),
+      response,
+      FinalResponseDto.fromResponse(
+        ResponseDto.buildCustomResponse(
+          {},
+          message,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        ),
+        path,
+      ),
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+
+  private _isFinalResponseDto(
+    exception: unknown,
+  ): exception is FinalResponseDto<unknown> {
+    return (
+      !!exception &&
+      typeof exception === 'object' &&
+      exception.constructor?.name === FinalResponseDto.name &&
+      'status' in exception &&
+      'path' in exception
+    );
+  }
+
+  private _isResponseDto(
+    exception: unknown,
+  ): exception is ResponseDto<unknown> {
+    return (
+      !!exception &&
+      typeof exception === 'object' &&
+      exception.constructor?.name === ResponseDto.name &&
+      'status' in exception &&
+      'message' in exception &&
+      'response' in exception &&
+      !('path' in exception)
     );
   }
 }

--- a/clarisa-back/src/shared/guards/permission.guard.ts
+++ b/clarisa-back/src/shared/guards/permission.guard.ts
@@ -3,9 +3,10 @@ import {
   CanActivate,
   ExecutionContext,
   Logger,
+  UnauthorizedException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ModuleRef, Reflector } from '@nestjs/core';
-import { Observable } from 'rxjs';
 import { User } from '../../api/user/entities/user.entity';
 import { UserService } from '../../api/user/user.service';
 import { IS_CLARISA_PAGE } from '../decorators/clarisa-page.decorator';
@@ -18,13 +19,9 @@ export class PermissionGuard implements CanActivate {
   constructor(
     private reflector: Reflector,
     private moduleRef: ModuleRef,
-  ) {
-    this.userService = this.moduleRef.get(UserService, { strict: false });
-  }
+  ) {}
 
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const isClarisaPage: boolean | undefined = this.reflector.get<boolean>(
       IS_CLARISA_PAGE,
       context.getClass(),
@@ -33,24 +30,45 @@ export class PermissionGuard implements CanActivate {
     const userPayload = request.user;
     const route = request.originalUrl as string;
 
-    return this.userService
-      .findOneByEmail(userPayload.email)
-      .then((userDb: User) => {
-        if (isClarisaPage) {
-          //TODO extract this magic constant
-          return userDb.id === 3043;
-        }
+    if (!userPayload?.email) {
+      throw new UnauthorizedException('Missing authenticated user');
+    }
 
-        const isRoutePermitted = (userDb.permissions ?? []).some((p) =>
-          route.includes(p),
-        );
-        if (!isRoutePermitted) {
-          this._logger.error(
-            `User ${userDb.email} tried to access route ${route} without permission`,
-          );
-        }
+    const userDb: User = await this._getUserService().findOneByEmail(
+      userPayload.email,
+    );
 
-        return isRoutePermitted;
-      });
+    if (!userDb) {
+      throw new UnauthorizedException('Authenticated user was not found');
+    }
+
+    if (isClarisaPage) {
+      //TODO extract this magic constant
+      return userDb.id === 3043;
+    }
+
+    const isRoutePermitted = (userDb.permissions ?? []).some((p) =>
+      route.includes(p),
+    );
+    if (!isRoutePermitted) {
+      this._logger.error(
+        `User ${userDb.email} tried to access route ${route} without permission`,
+      );
+      throw new ForbiddenException(
+        `User is not permitted to access route ${route}`,
+      );
+    }
+
+    return true;
+  }
+
+  private _getUserService(): UserService {
+    if (!this.userService) {
+      this.userService = this.moduleRef.get(UserService, { strict: false });
+    }
+    if (!this.userService) {
+      throw new UnauthorizedException('User service is unavailable');
+    }
+    return this.userService;
   }
 }


### PR DESCRIPTION
## Summary
- enable JWT or `X-API-Key` authentication on partner-request write endpoints
- enforce `partner-requests:create` scope for API-key callers
- preserve JWT permission checks and improve authentication error handling
- document the rollout and add focused unit coverage

## Validation
- 19 focused unit tests passed
- lint passed
- backend build passed
- verified locally: JWT and scoped TEST API key return 201; missing auth returns 401; missing scope returns 401