### PR TITLE
feat(innovation): results overview endpoint for PRMS innovations

### DIFF
--- a/clarisa-back/docs/results-overview-endpoint.md
+++ b/clarisa-back/docs/results-overview-endpoint.md
@@ -1,6 +1,6 @@
 # Innovations Overview Endpoint
 
-`GET /results-overview`
+`GET /integration/innovation/results-overview`
 
 Returns a paginated list of PRMS innovation results with their associated science programs, centers, phase, and status. The endpoint is backed by `vw_results_innovations_overview` and is scoped exclusively to innovation result types (Innovation Use, Innovation Development, Innovation Use IPSR).
 
@@ -15,7 +15,7 @@ Returns a paginated list of PRMS innovation results with their associated scienc
 
 **Full URL:**
 ```
-GET {base}/results-overview
+GET {base}/integration/innovation/results-overview
 ```
 
 ---

--- a/clarisa-back/docs/results-overview-endpoint.md
+++ b/clarisa-back/docs/results-overview-endpoint.md
@@ -1,0 +1,238 @@
+# Innovations Overview Endpoint
+
+`GET /results-overview`
+
+Returns a paginated list of PRMS innovation results with their associated science programs, centers, phase, and status. The endpoint is backed by `vw_results_innovations_overview` and is scoped exclusively to innovation result types (Innovation Use, Innovation Development, Innovation Use IPSR).
+
+---
+
+## Environments
+
+| Environment | Base URL |
+|---|---|
+| **Test** | `https://clarisatest-back.ciat.cgiar.org` |
+| **Production** | `https://api.clarisa.cgiar.org` |
+
+**Full URL:**
+```
+GET {base}/results-overview
+```
+
+---
+
+## Query Parameters
+
+All parameters are optional.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `version_id` | `integer` | Filter by reporting phase/version ID. |
+| `status_id` | `integer[]` | Filter by one or more result status IDs. Repeatable: `status_id=1&status_id=2`. |
+| `result_type_id` | `integer[]` | Filter by one or more result type IDs. Repeatable. See type reference below. |
+| `initiative_id` | `integer` | Filter by science program ID. Matches both lead and contributing programs. |
+| `center_code` | `string` | Filter by center code (e.g. `CIP`, `CIMMYT`). Matches both lead and contributing centers. |
+| `search` | `string` | Partial text match on result title and description. |
+| `page` | `integer` | Page number, 1-based. Default: `1`. |
+| `limit` | `integer` | Records per page. Default: `25`. Maximum: `100`. |
+
+### Result type reference
+
+The view exposes only innovation types:
+
+| ID | Name |
+|---|---|
+| 2 | Innovation Use |
+| 7 | Innovation Development |
+| 10 | Innovation Use IPSR |
+
+### Status ID reference
+
+| ID | Name |
+|---|---|
+| 1 | Editing |
+| 2 | Quality Assessed |
+| 3 | Submitted |
+| 4 | Discontinued |
+| 5 | Pending Review |
+| 6 | Approved |
+| 7 | Rejected |
+
+---
+
+## Filtering behavior
+
+- **`version_id`** — exact match on the phase. Use the `/versioning` endpoint to discover available phase IDs.
+- **`status_id`** — IN clause; pass the parameter multiple times for OR logic.
+- **`result_type_id`** — IN clause; pass multiple times to include more than one type.
+- **`initiative_id`** — matches a result if the given initiative is either the **lead** program (`initiative_role_id = 1`) or a **contributing** program (`initiative_role_id = 2`). Resolved via a direct subquery on `results_by_inititiative`.
+- **`center_code`** — matches a result if the given center is either the **lead center** (`is_leading_result = true`) or a contributing center. Resolved via a direct subquery on `results_center`.
+- **`search`** — `LIKE %term%` applied to both `result_title` and `result_description`. Case-insensitive.
+- All active filters are combined with **AND**.
+
+---
+
+## Response structure
+
+```json
+{
+  "data": [ ... ],
+  "pagination": {
+    "page": 1,
+    "limit": 25,
+    "total": 142,
+    "total_pages": 6
+  }
+}
+```
+
+### Result object
+
+| Field | Type | Description |
+|---|---|---|
+| `result_id` | `integer` | Internal result ID. |
+| `result_code` | `integer` | Human-readable result code. |
+| `result_title` | `string` | Result title. |
+| `result_description` | `string \| null` | Result description. |
+| `result_type_id` | `integer` | Result type ID (2, 7, or 10). |
+| `result_type` | `string` | Result type name. |
+| `version_id` | `integer` | Reporting phase ID. |
+| `phase_name` | `string` | Reporting phase name. |
+| `phase_year` | `integer \| null` | Reporting phase year. |
+| `status_id` | `integer` | Status ID. |
+| `status_name` | `string` | Status label. |
+| `lead_initiative_program_id` | `integer \| null` | ID of the lead science program. |
+| `lead_initiative_program_official_code` | `string \| null` | Official code of the lead science program. |
+| `lead_initiative_program_short_name` | `string \| null` | Short name of the lead science program. |
+| `contributing_initiative_program_official_codes` | `string \| null` | Semicolon-separated official codes of contributing science programs (e.g. `INIT-5;INIT-8`). |
+| `contributing_initiative_program_short_names` | `string \| null` | Semicolon-separated short names of contributing science programs. |
+| `lead_center_code` | `string \| null` | Code of the lead center (e.g. `CIP`). |
+| `lead_center_acronym` | `string \| null` | Acronym of the lead center. |
+| `contributing_center_codes` | `string \| null` | Semicolon-separated codes of contributing centers. |
+| `contributing_center_acronyms` | `string \| null` | Semicolon-separated acronyms of contributing centers. |
+
+---
+
+## Examples
+
+### All innovations for a phase
+
+```
+GET /results-overview?version_id=3
+```
+
+### Only Innovation Development results
+
+```
+GET /results-overview?result_type_id=7
+```
+
+### Innovation Use and Innovation Development combined
+
+```
+GET /results-overview?result_type_id=2&result_type_id=7
+```
+
+### Results by status (multiple)
+
+```
+GET /results-overview?status_id=2&status_id=3
+```
+
+### Results for a specific science program (lead or contributing)
+
+```
+GET /results-overview?initiative_id=12
+```
+
+### Results where a center is involved (lead or contributing)
+
+```
+GET /results-overview?center_code=CIP
+```
+
+### Full-text search with pagination
+
+```
+GET /results-overview?search=maize&page=2&limit=10
+```
+
+### Combined filters
+
+```
+GET /results-overview?version_id=3&result_type_id=7&status_id=2&center_code=CIP&page=1&limit=50
+```
+
+### cURL (test environment)
+
+```bash
+curl -X GET \
+  "https://clarisatest-back.ciat.cgiar.org/results-overview?version_id=3&result_type_id=7&status_id=2&limit=10" \
+  -H "Accept: application/json"
+```
+
+### cURL (production)
+
+```bash
+curl -X GET \
+  "https://api.clarisa.cgiar.org/results-overview?version_id=3&result_type_id=7&status_id=2&limit=10" \
+  -H "Accept: application/json"
+```
+
+---
+
+## Example response
+
+```json
+{
+  "data": [
+    {
+      "result_id": 1284,
+      "result_code": 542,
+      "result_title": "Improved drought-tolerant maize varieties adopted in East Africa",
+      "result_description": "Describes the adoption of varieties...",
+      "result_type_id": 7,
+      "result_type": "Innovation Development",
+      "version_id": 3,
+      "phase_name": "Reporting 2024",
+      "phase_year": 2024,
+      "status_id": 2,
+      "status_name": "Quality Assessed",
+      "lead_initiative_program_id": 12,
+      "lead_initiative_program_official_code": "INIT-12",
+      "lead_initiative_program_short_name": "Excellence in Agronomy",
+      "contributing_initiative_program_official_codes": "INIT-5;INIT-8",
+      "contributing_initiative_program_short_names": "Food Systems;Nutrition Innovation",
+      "lead_center_code": "CIMMYT",
+      "lead_center_acronym": "CIMMYT",
+      "contributing_center_codes": "CIP;ICRAF",
+      "contributing_center_acronyms": "CIP;ICRAF"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 10,
+    "total": 142,
+    "total_pages": 15
+  }
+}
+```
+
+---
+
+## Error responses
+
+| HTTP Status | Description |
+|---|---|
+| `400 Bad Request` | Invalid parameter type or value out of allowed range. |
+| `500 Internal Server Error` | Unexpected server-side error. |
+
+---
+
+## Notes
+
+- Results with `is_active = false` are excluded from all responses.
+- The view is scoped to innovation result types only (`result_type_id IN (2, 7, 10)`). Other result types are not returned regardless of filters.
+- Multi-value fields (`contributing_*`) use `;` as separator. Split on `;` to get individual values.
+- `initiative_id` and `center_code` filters query the source tables directly (not the view columns), so they correctly match both lead and contributing associations.
+- The `version_id` parameter is strongly recommended in production to avoid full-table scans across all phases.
+- Swagger UI is available at `{base}/api` for interactive exploration.

--- a/clarisa-back/src/integration/innovation/innovation.module.ts
+++ b/clarisa-back/src/integration/innovation/innovation.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ResultsOverviewController } from '../reporting/results-overview.controller';
+import { ResultsOverviewService } from '../reporting/services/results-overview.service';
+
+@Module({
+  providers: [ResultsOverviewService],
+  controllers: [ResultsOverviewController],
+  exports: [ResultsOverviewService],
+})
+export class InnovationModule {}

--- a/clarisa-back/src/integration/integration.module.ts
+++ b/clarisa-back/src/integration/integration.module.ts
@@ -6,6 +6,7 @@ import { OpenSearchModule } from './opensearch/open-search.module';
 import { HttpModule } from '@nestjs/axios';
 import { HandlebarsTemplateModule } from '../api/handlebars-template/handlebars-template.module';
 import { ReportingModule } from './reporting/reporting.module';
+import { InnovationModule } from './innovation/innovation.module';
 
 @Module({
   imports: [
@@ -14,9 +15,10 @@ import { ReportingModule } from './reporting/reporting.module';
     HttpModule,
     HandlebarsTemplateModule,
     ReportingModule,
+    InnovationModule,
   ],
   providers: [QaApi],
   controllers: [IntegrationController],
-  exports: [QaApi, ReportingModule],
+  exports: [QaApi, ReportingModule, InnovationModule],
 })
 export class IntegrationModule {}

--- a/clarisa-back/src/integration/integration.routes.ts
+++ b/clarisa-back/src/integration/integration.routes.ts
@@ -3,6 +3,7 @@ import { CronjobModule } from './cronjob/cronjob.module';
 import { OpenSearchModule } from './opensearch/open-search.module';
 import { openSearchRoutes } from './opensearch/open-search.routes';
 import { ReportingModule } from './reporting/reporting.module';
+import { InnovationModule } from './innovation/innovation.module';
 
 export const integrationRoutes: Routes = [
   {
@@ -17,5 +18,9 @@ export const integrationRoutes: Routes = [
   {
     path: 'taat',
     module: ReportingModule,
+  },
+  {
+    path: 'innovation',
+    module: InnovationModule,
   },
 ];

--- a/clarisa-back/src/integration/reporting/dto/results-overview-query.dto.ts
+++ b/clarisa-back/src/integration/reporting/dto/results-overview-query.dto.ts
@@ -32,6 +32,21 @@ export class ResultsOverviewQueryDto {
 
   @ApiPropertyOptional({
     description:
+      'Filter by result type ID. View exposes types 2 (Innovation Use), 7 (Innovation Development), 10 (Innovation Use IPSR)',
+    type: [Number],
+    example: [2, 7],
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (Array.isArray(value)) return value.map(Number);
+    return [Number(value)];
+  })
+  @IsArray()
+  @IsInt({ each: true })
+  result_type_id?: number[];
+
+  @ApiPropertyOptional({
+    description:
       'Filter by initiative/science-program ID (lead or contributing)',
   })
   @IsOptional()

--- a/clarisa-back/src/integration/reporting/dto/results-overview-query.dto.ts
+++ b/clarisa-back/src/integration/reporting/dto/results-overview-query.dto.ts
@@ -1,0 +1,71 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class ResultsOverviewQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by phase/version ID' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  version_id?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by one or more status IDs',
+    type: [Number],
+    example: [1, 2],
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (Array.isArray(value)) return value.map(Number);
+    return [Number(value)];
+  })
+  @IsArray()
+  @IsInt({ each: true })
+  status_id?: number[];
+
+  @ApiPropertyOptional({
+    description:
+      'Filter by initiative/science-program ID (lead or contributing)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  initiative_id?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by center code (lead or contributing)',
+    example: 'CIP',
+  })
+  @IsOptional()
+  @IsString()
+  center_code?: string;
+
+  @ApiPropertyOptional({
+    description: 'Full-text search on result title and description',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 25, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 25;
+}

--- a/clarisa-back/src/integration/reporting/dto/results-overview-response.dto.ts
+++ b/clarisa-back/src/integration/reporting/dto/results-overview-response.dto.ts
@@ -6,6 +6,13 @@ export class ResultsOverviewItemDto {
   @ApiProperty() result_title: string;
   @ApiPropertyOptional() result_description: string | null;
 
+  @ApiProperty() result_type_id: number;
+  @ApiProperty({
+    description:
+      'Result type name (Innovation Development, Innovation Use, Innovation Package)',
+  })
+  result_type: string;
+
   @ApiProperty() version_id: number;
   @ApiProperty() phase_name: string;
   @ApiPropertyOptional() phase_year: number | null;
@@ -18,17 +25,14 @@ export class ResultsOverviewItemDto {
   @ApiPropertyOptional() lead_initiative_program_short_name: string | null;
 
   @ApiPropertyOptional({
-    description: 'Semicolon-separated contributing initiative IDs',
-  })
-  contributing_initiative_program_ids: string | null;
-
-  @ApiPropertyOptional({
-    description: 'Semicolon-separated contributing initiative official codes',
+    description:
+      'Semicolon-separated official codes of contributing science programs',
   })
   contributing_initiative_program_official_codes: string | null;
 
   @ApiPropertyOptional({
-    description: 'Semicolon-separated contributing initiative short names',
+    description:
+      'Semicolon-separated short names of contributing science programs',
   })
   contributing_initiative_program_short_names: string | null;
 
@@ -36,12 +40,12 @@ export class ResultsOverviewItemDto {
   @ApiPropertyOptional() lead_center_acronym: string | null;
 
   @ApiPropertyOptional({
-    description: 'Semicolon-separated contributing center codes',
+    description: 'Semicolon-separated codes of contributing centers',
   })
   contributing_center_codes: string | null;
 
   @ApiPropertyOptional({
-    description: 'Semicolon-separated contributing center acronyms',
+    description: 'Semicolon-separated acronyms of contributing centers',
   })
   contributing_center_acronyms: string | null;
 }

--- a/clarisa-back/src/integration/reporting/dto/results-overview-response.dto.ts
+++ b/clarisa-back/src/integration/reporting/dto/results-overview-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ResultsOverviewItemDto {
+  @ApiProperty() result_id: number;
+  @ApiProperty() result_code: number;
+  @ApiProperty() result_title: string;
+  @ApiPropertyOptional() result_description: string | null;
+
+  @ApiProperty() version_id: number;
+  @ApiProperty() phase_name: string;
+  @ApiPropertyOptional() phase_year: number | null;
+
+  @ApiProperty() status_id: number;
+  @ApiProperty() status_name: string;
+
+  @ApiPropertyOptional() lead_initiative_program_id: number | null;
+  @ApiPropertyOptional() lead_initiative_program_official_code: string | null;
+  @ApiPropertyOptional() lead_initiative_program_short_name: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Semicolon-separated contributing initiative IDs',
+  })
+  contributing_initiative_program_ids: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Semicolon-separated contributing initiative official codes',
+  })
+  contributing_initiative_program_official_codes: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Semicolon-separated contributing initiative short names',
+  })
+  contributing_initiative_program_short_names: string | null;
+
+  @ApiPropertyOptional() lead_center_code: string | null;
+  @ApiPropertyOptional() lead_center_acronym: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Semicolon-separated contributing center codes',
+  })
+  contributing_center_codes: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Semicolon-separated contributing center acronyms',
+  })
+  contributing_center_acronyms: string | null;
+}
+
+export class PaginationMetaDto {
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+  @ApiProperty() total: number;
+  @ApiProperty() total_pages: number;
+}
+
+export class ResultsOverviewPaginatedDto {
+  @ApiProperty({ type: [ResultsOverviewItemDto] })
+  data: ResultsOverviewItemDto[];
+
+  @ApiProperty({ type: PaginationMetaDto })
+  pagination: PaginationMetaDto;
+}

--- a/clarisa-back/src/integration/reporting/reporting.module.ts
+++ b/clarisa-back/src/integration/reporting/reporting.module.ts
@@ -5,6 +5,8 @@ import { ReportingApi } from './reporting.api';
 import { reportingDataSource } from '../../shared/database/reporting-data-source';
 import { InnovationService } from './services/taat-innovation.service';
 import { InnovationController } from './taat-innovation.controller';
+import { ResultsOverviewService } from './services/results-overview.service';
+import { ResultsOverviewController } from './results-overview.controller';
 
 @Module({
   imports: [
@@ -14,8 +16,8 @@ import { InnovationController } from './taat-innovation.controller';
       name: 'reporting',
     }),
   ],
-  providers: [ReportingApi, InnovationService],
-  controllers: [InnovationController],
-  exports: [ReportingApi, InnovationService],
+  providers: [ReportingApi, InnovationService, ResultsOverviewService],
+  controllers: [InnovationController, ResultsOverviewController],
+  exports: [ReportingApi, InnovationService, ResultsOverviewService],
 })
 export class ReportingModule {}

--- a/clarisa-back/src/integration/reporting/reporting.module.ts
+++ b/clarisa-back/src/integration/reporting/reporting.module.ts
@@ -5,8 +5,6 @@ import { ReportingApi } from './reporting.api';
 import { reportingDataSource } from '../../shared/database/reporting-data-source';
 import { InnovationService } from './services/taat-innovation.service';
 import { InnovationController } from './taat-innovation.controller';
-import { ResultsOverviewService } from './services/results-overview.service';
-import { ResultsOverviewController } from './results-overview.controller';
 
 @Module({
   imports: [
@@ -16,8 +14,8 @@ import { ResultsOverviewController } from './results-overview.controller';
       name: 'reporting',
     }),
   ],
-  providers: [ReportingApi, InnovationService, ResultsOverviewService],
-  controllers: [InnovationController, ResultsOverviewController],
-  exports: [ReportingApi, InnovationService, ResultsOverviewService],
+  providers: [ReportingApi, InnovationService],
+  controllers: [InnovationController],
+  exports: [ReportingApi, InnovationService],
 })
 export class ReportingModule {}

--- a/clarisa-back/src/integration/reporting/results-overview.controller.spec.ts
+++ b/clarisa-back/src/integration/reporting/results-overview.controller.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ResultsOverviewController } from './results-overview.controller';
+import { ResultsOverviewService } from './services/results-overview.service';
+import { ResultsOverviewQueryDto } from './dto/results-overview-query.dto';
+import { ResultsOverviewPaginatedDto } from './dto/results-overview-response.dto';
+
+const MOCK_PAGINATED: ResultsOverviewPaginatedDto = {
+  data: [
+    {
+      result_id: 1,
+      result_code: 100,
+      result_title: 'Test Result',
+      result_description: 'A description',
+      version_id: 3,
+      phase_name: 'Phase 2024',
+      phase_year: 2024,
+      status_id: 2,
+      status_name: 'Quality Assessed',
+      lead_initiative_program_id: 12,
+      lead_initiative_program_official_code: 'INIT-12',
+      lead_initiative_program_short_name: 'Agri Innovations',
+      contributing_initiative_program_ids: '5;8',
+      contributing_initiative_program_official_codes: 'INIT-5;INIT-8',
+      contributing_initiative_program_short_names: 'Food Systems;Nutrition',
+      lead_center_code: 'CIP',
+      lead_center_acronym: 'CIP',
+      contributing_center_codes: 'CIMMYT;ICRAF',
+      contributing_center_acronyms: 'CIMMYT;ICRAF',
+    },
+  ],
+  pagination: { page: 1, limit: 25, total: 1, total_pages: 1 },
+};
+
+describe('ResultsOverviewController', () => {
+  let controller: ResultsOverviewController;
+  let mockService: jest.Mocked<ResultsOverviewService>;
+
+  beforeEach(async () => {
+    mockService = {
+      getResultsOverview: jest.fn(),
+    } as unknown as jest.Mocked<ResultsOverviewService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResultsOverviewController],
+      providers: [{ provide: ResultsOverviewService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<ResultsOverviewController>(
+      ResultsOverviewController,
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getResultsOverview', () => {
+    it('should return the paginated response from the service', async () => {
+      mockService.getResultsOverview.mockResolvedValue(MOCK_PAGINATED);
+      const query: ResultsOverviewQueryDto = {
+        version_id: 3,
+        page: 1,
+        limit: 25,
+      };
+
+      const result = await controller.getResultsOverview(query);
+
+      expect(mockService.getResultsOverview).toHaveBeenCalledWith(query);
+      expect(result).toEqual(MOCK_PAGINATED);
+    });
+
+    it('should forward all query params to the service', async () => {
+      mockService.getResultsOverview.mockResolvedValue(MOCK_PAGINATED);
+      const query: ResultsOverviewQueryDto = {
+        version_id: 3,
+        status_id: [1, 2],
+        initiative_id: 12,
+        center_code: 'CIP',
+        search: 'maize',
+        page: 2,
+        limit: 10,
+      };
+
+      await controller.getResultsOverview(query);
+
+      expect(mockService.getResultsOverview).toHaveBeenCalledWith(query);
+    });
+
+    it('should throw HttpException with INTERNAL_SERVER_ERROR when service fails', async () => {
+      mockService.getResultsOverview.mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await expect(controller.getResultsOverview({})).rejects.toThrow(
+        new HttpException(
+          'Failed to retrieve results overview',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        ),
+      );
+    });
+  });
+});

--- a/clarisa-back/src/integration/reporting/results-overview.controller.spec.ts
+++ b/clarisa-back/src/integration/reporting/results-overview.controller.spec.ts
@@ -10,8 +10,10 @@ const MOCK_PAGINATED: ResultsOverviewPaginatedDto = {
     {
       result_id: 1,
       result_code: 100,
-      result_title: 'Test Result',
+      result_title: 'Test Innovation',
       result_description: 'A description',
+      result_type_id: 7,
+      result_type: 'Innovation Development',
       version_id: 3,
       phase_name: 'Phase 2024',
       phase_year: 2024,
@@ -20,7 +22,6 @@ const MOCK_PAGINATED: ResultsOverviewPaginatedDto = {
       lead_initiative_program_id: 12,
       lead_initiative_program_official_code: 'INIT-12',
       lead_initiative_program_short_name: 'Agri Innovations',
-      contributing_initiative_program_ids: '5;8',
       contributing_initiative_program_official_codes: 'INIT-5;INIT-8',
       contributing_initiative_program_short_names: 'Food Systems;Nutrition',
       lead_center_code: 'CIP',
@@ -77,6 +78,7 @@ describe('ResultsOverviewController', () => {
       const query: ResultsOverviewQueryDto = {
         version_id: 3,
         status_id: [1, 2],
+        result_type_id: [7],
         initiative_id: 12,
         center_code: 'CIP',
         search: 'maize',

--- a/clarisa-back/src/integration/reporting/results-overview.controller.ts
+++ b/clarisa-back/src/integration/reporting/results-overview.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Query,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ResultsOverviewQueryDto } from './dto/results-overview-query.dto';
+import { ResultsOverviewPaginatedDto } from './dto/results-overview-response.dto';
+import { ResultsOverviewService } from './services/results-overview.service';
+
+@ApiTags('Results Overview')
+@Controller('results-overview')
+export class ResultsOverviewController {
+  private readonly logger = new Logger(ResultsOverviewController.name);
+
+  constructor(
+    private readonly resultsOverviewService: ResultsOverviewService,
+  ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get paginated results overview',
+    description: `
+Returns a paginated list of PRMS results with their science programs, centers, phase, and status.
+
+**Filters available:**
+- \`version_id\` — restrict to a specific reporting phase
+- \`status_id\` — one or more status IDs (repeatable: \`status_id=1&status_id=2\`)
+- \`initiative_id\` — matches both lead and contributing science programs
+- \`center_code\` — matches both lead and contributing centers (e.g. \`CIP\`, \`CIMMYT\`)
+- \`search\` — partial match on title and description
+
+**Pagination:**
+- \`page\` — 1-based page number (default: 1)
+- \`limit\` — records per page, max 100 (default: 25)
+    `.trim(),
+  })
+  @ApiOkResponse({ type: ResultsOverviewPaginatedDto })
+  async getResultsOverview(
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: ResultsOverviewQueryDto,
+  ): Promise<ResultsOverviewPaginatedDto> {
+    try {
+      return await this.resultsOverviewService.getResultsOverview(query);
+    } catch (error) {
+      this.logger.error('Error fetching results overview', error);
+      throw new HttpException(
+        'Failed to retrieve results overview',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/clarisa-back/src/integration/reporting/services/results-overview.service.spec.ts
+++ b/clarisa-back/src/integration/reporting/services/results-overview.service.spec.ts
@@ -1,0 +1,229 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { ResultsOverviewService } from './results-overview.service';
+import { ResultsOverviewQueryDto } from '../dto/results-overview-query.dto';
+
+const MOCK_ROW = {
+  result_id: 1,
+  result_code: 100,
+  result_title: 'Test Result',
+  result_description: 'A description',
+  version_id: 3,
+  phase_name: 'Phase 2024',
+  phase_year: 2024,
+  status_id: 2,
+  status_name: 'Quality Assessed',
+  lead_initiative_program_id: 12,
+  lead_initiative_program_official_code: 'INIT-12',
+  lead_initiative_program_short_name: 'Agri Innovations',
+  contributing_initiative_program_ids: '5;8',
+  contributing_initiative_program_official_codes: 'INIT-5;INIT-8',
+  contributing_initiative_program_short_names: 'Food Systems;Nutrition',
+  lead_center_code: 'CIP',
+  lead_center_acronym: 'CIP',
+  contributing_center_codes: 'CIMMYT;ICRAF',
+  contributing_center_acronyms: 'CIMMYT;ICRAF',
+};
+
+describe('ResultsOverviewService', () => {
+  let service: ResultsOverviewService;
+  let mockQuery: jest.Mock;
+
+  beforeEach(async () => {
+    mockQuery = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResultsOverviewService,
+        {
+          provide: getDataSourceToken('reporting'),
+          useValue: { query: mockQuery },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ResultsOverviewService>(ResultsOverviewService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getResultsOverview', () => {
+    const setupMocks = (rows = [MOCK_ROW], total = 1) => {
+      mockQuery
+        .mockResolvedValueOnce(rows)
+        .mockResolvedValueOnce([{ total: String(total) }]);
+    };
+
+    it('should return paginated results with default params', async () => {
+      setupMocks();
+      const query: ResultsOverviewQueryDto = {};
+
+      const result = await service.getResultsOverview(query);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].result_code).toBe(100);
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 25,
+        total: 1,
+        total_pages: 1,
+      });
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('should build query without WHERE clause when no filters provided', async () => {
+      setupMocks([], 0);
+      await service.getResultsOverview({});
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).not.toContain('WHERE');
+      expect(dataCall[1]).toEqual([25, 0]);
+    });
+
+    it('should apply version_id filter', async () => {
+      setupMocks();
+      await service.getResultsOverview({ version_id: 3 });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.version_id = ?');
+      expect(dataCall[1]).toContain(3);
+    });
+
+    it('should apply status_id filter with a single value', async () => {
+      setupMocks();
+      await service.getResultsOverview({ status_id: [2] });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.status_id IN (?)');
+      expect(dataCall[1]).toContain(2);
+    });
+
+    it('should apply status_id filter with multiple values', async () => {
+      setupMocks();
+      await service.getResultsOverview({ status_id: [1, 2, 3] });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.status_id IN (?, ?, ?)');
+      expect(dataCall[1]).toContain(1);
+      expect(dataCall[1]).toContain(2);
+      expect(dataCall[1]).toContain(3);
+    });
+
+    it('should apply initiative_id filter on lead and contributing columns', async () => {
+      setupMocks();
+      await service.getResultsOverview({ initiative_id: 12 });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.lead_initiative_program_id = ?');
+      expect(dataCall[0]).toContain(
+        "FIND_IN_SET(?, REPLACE(vro.contributing_initiative_program_ids, ';', ','))",
+      );
+      expect(dataCall[1]).toContain(12);
+      expect(dataCall[1]).toContain('12');
+    });
+
+    it('should apply center_code filter on lead and contributing columns', async () => {
+      setupMocks();
+      await service.getResultsOverview({ center_code: 'CIP' });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.lead_center_code = ?');
+      expect(dataCall[0]).toContain(
+        "FIND_IN_SET(?, REPLACE(vro.contributing_center_codes, ';', ','))",
+      );
+      expect(dataCall[1]).toContain('CIP');
+    });
+
+    it('should apply search filter on title and description', async () => {
+      setupMocks();
+      await service.getResultsOverview({ search: 'food' });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain(
+        '(vro.result_title LIKE ? OR vro.result_description LIKE ?)',
+      );
+      expect(dataCall[1]).toContain('%food%');
+    });
+
+    it('should ignore blank search strings', async () => {
+      setupMocks([], 0);
+      await service.getResultsOverview({ search: '   ' });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).not.toContain('LIKE');
+    });
+
+    it('should combine multiple filters with AND', async () => {
+      setupMocks();
+      await service.getResultsOverview({
+        version_id: 3,
+        status_id: [1, 2],
+        initiative_id: 12,
+        center_code: 'CIP',
+        search: 'maize',
+      });
+
+      const [dataCall] = mockQuery.mock.calls;
+      const sql: string = dataCall[0];
+      expect(sql).toContain('vro.version_id = ?');
+      expect(sql).toContain('vro.status_id IN (?, ?)');
+      expect(sql).toContain('vro.lead_initiative_program_id = ?');
+      expect(sql).toContain('vro.lead_center_code = ?');
+      expect(sql).toContain('vro.result_title LIKE ?');
+      expect((sql.match(/AND/g) ?? []).length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should pass the same params to both data and count queries', async () => {
+      setupMocks();
+      await service.getResultsOverview({ version_id: 5, status_id: [2] });
+
+      const [dataCall, countCall] = mockQuery.mock.calls;
+      // count params must be a subset of data params (data appends limit+offset)
+      expect(dataCall[1]).toEqual(expect.arrayContaining(countCall[1]));
+      expect(dataCall[1].length).toBe(countCall[1].length + 2);
+    });
+
+    it('should calculate pagination metadata correctly', async () => {
+      setupMocks([MOCK_ROW], 47);
+      const result = await service.getResultsOverview({ page: 2, limit: 10 });
+
+      expect(result.pagination).toEqual({
+        page: 2,
+        limit: 10,
+        total: 47,
+        total_pages: 5,
+      });
+    });
+
+    it('should apply correct LIMIT and OFFSET based on page and limit', async () => {
+      setupMocks([], 0);
+      await service.getResultsOverview({ page: 3, limit: 20 });
+
+      const [dataCall] = mockQuery.mock.calls;
+      const dataParams: number[] = dataCall[1];
+      expect(dataParams.at(-2)).toBe(20); // LIMIT
+      expect(dataParams.at(-1)).toBe(40); // OFFSET = (3-1)*20
+    });
+
+    it('should return empty data array and total 0 when no rows found', async () => {
+      setupMocks([], 0);
+      const result = await service.getResultsOverview({});
+
+      expect(result.data).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.total_pages).toBe(0);
+    });
+
+    it('should propagate errors thrown by the data source', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('DB connection lost'));
+
+      await expect(service.getResultsOverview({})).rejects.toThrow(
+        'DB connection lost',
+      );
+    });
+  });
+});

--- a/clarisa-back/src/integration/reporting/services/results-overview.service.spec.ts
+++ b/clarisa-back/src/integration/reporting/services/results-overview.service.spec.ts
@@ -1,13 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getDataSourceToken } from '@nestjs/typeorm';
 import { ResultsOverviewService } from './results-overview.service';
-import { ResultsOverviewQueryDto } from '../dto/results-overview-query.dto';
 
 const MOCK_ROW = {
   result_id: 1,
   result_code: 100,
-  result_title: 'Test Result',
+  result_title: 'Test Innovation',
   result_description: 'A description',
+  result_type_id: 7,
+  result_type: 'Innovation Development',
   version_id: 3,
   phase_name: 'Phase 2024',
   phase_year: 2024,
@@ -16,7 +17,6 @@ const MOCK_ROW = {
   lead_initiative_program_id: 12,
   lead_initiative_program_official_code: 'INIT-12',
   lead_initiative_program_short_name: 'Agri Innovations',
-  contributing_initiative_program_ids: '5;8',
   contributing_initiative_program_official_codes: 'INIT-5;INIT-8',
   contributing_initiative_program_short_names: 'Food Systems;Nutrition',
   lead_center_code: 'CIP',
@@ -60,12 +60,10 @@ describe('ResultsOverviewService', () => {
 
     it('should return paginated results with default params', async () => {
       setupMocks();
-      const query: ResultsOverviewQueryDto = {};
-
-      const result = await service.getResultsOverview(query);
+      const result = await service.getResultsOverview({});
 
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].result_code).toBe(100);
+      expect(result.data[0].result_type).toBe('Innovation Development');
       expect(result.pagination).toEqual({
         page: 1,
         limit: 25,
@@ -73,6 +71,14 @@ describe('ResultsOverviewService', () => {
         total_pages: 1,
       });
       expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('should query the correct view name', async () => {
+      setupMocks([], 0);
+      await service.getResultsOverview({});
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vw_results_innovations_overview');
     });
 
     it('should build query without WHERE clause when no filters provided', async () => {
@@ -109,32 +115,52 @@ describe('ResultsOverviewService', () => {
       const [dataCall] = mockQuery.mock.calls;
       expect(dataCall[0]).toContain('vro.status_id IN (?, ?, ?)');
       expect(dataCall[1]).toContain(1);
-      expect(dataCall[1]).toContain(2);
       expect(dataCall[1]).toContain(3);
     });
 
-    it('should apply initiative_id filter on lead and contributing columns', async () => {
+    it('should apply result_type_id filter with a single value', async () => {
+      setupMocks();
+      await service.getResultsOverview({ result_type_id: [7] });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.result_type_id IN (?)');
+      expect(dataCall[1]).toContain(7);
+    });
+
+    it('should apply result_type_id filter with multiple values', async () => {
+      setupMocks();
+      await service.getResultsOverview({ result_type_id: [2, 7] });
+
+      const [dataCall] = mockQuery.mock.calls;
+      expect(dataCall[0]).toContain('vro.result_type_id IN (?, ?)');
+      expect(dataCall[1]).toContain(2);
+      expect(dataCall[1]).toContain(7);
+    });
+
+    it('should apply initiative_id filter using EXISTS subquery against source table', async () => {
       setupMocks();
       await service.getResultsOverview({ initiative_id: 12 });
 
       const [dataCall] = mockQuery.mock.calls;
-      expect(dataCall[0]).toContain('vro.lead_initiative_program_id = ?');
-      expect(dataCall[0]).toContain(
-        "FIND_IN_SET(?, REPLACE(vro.contributing_initiative_program_ids, ';', ','))",
-      );
+      const sql: string = dataCall[0];
+      expect(sql).toContain('EXISTS');
+      expect(sql).toContain('results_by_inititiative');
+      expect(sql).toContain('rbi2.result_id      = vro.result_id');
+      expect(sql).toContain('rbi2.inititiative_id = ?');
+      // Only one param pushed (not two as in the old FIND_IN_SET approach)
       expect(dataCall[1]).toContain(12);
-      expect(dataCall[1]).toContain('12');
     });
 
-    it('should apply center_code filter on lead and contributing columns', async () => {
+    it('should apply center_code filter using EXISTS subquery against source table', async () => {
       setupMocks();
       await service.getResultsOverview({ center_code: 'CIP' });
 
       const [dataCall] = mockQuery.mock.calls;
-      expect(dataCall[0]).toContain('vro.lead_center_code = ?');
-      expect(dataCall[0]).toContain(
-        "FIND_IN_SET(?, REPLACE(vro.contributing_center_codes, ';', ','))",
-      );
+      const sql: string = dataCall[0];
+      expect(sql).toContain('EXISTS');
+      expect(sql).toContain('results_center');
+      expect(sql).toContain('rc2.result_id  = vro.result_id');
+      expect(sql).toContain('rc2.center_id  = ?');
       expect(dataCall[1]).toContain('CIP');
     });
 
@@ -157,11 +183,12 @@ describe('ResultsOverviewService', () => {
       expect(dataCall[0]).not.toContain('LIKE');
     });
 
-    it('should combine multiple filters with AND', async () => {
+    it('should combine all filters with AND', async () => {
       setupMocks();
       await service.getResultsOverview({
         version_id: 3,
         status_id: [1, 2],
+        result_type_id: [7],
         initiative_id: 12,
         center_code: 'CIP',
         search: 'maize',
@@ -171,8 +198,8 @@ describe('ResultsOverviewService', () => {
       const sql: string = dataCall[0];
       expect(sql).toContain('vro.version_id = ?');
       expect(sql).toContain('vro.status_id IN (?, ?)');
-      expect(sql).toContain('vro.lead_initiative_program_id = ?');
-      expect(sql).toContain('vro.lead_center_code = ?');
+      expect(sql).toContain('vro.result_type_id IN (?)');
+      expect(sql).toContain('EXISTS');
       expect(sql).toContain('vro.result_title LIKE ?');
       expect((sql.match(/AND/g) ?? []).length).toBeGreaterThanOrEqual(4);
     });
@@ -182,7 +209,6 @@ describe('ResultsOverviewService', () => {
       await service.getResultsOverview({ version_id: 5, status_id: [2] });
 
       const [dataCall, countCall] = mockQuery.mock.calls;
-      // count params must be a subset of data params (data appends limit+offset)
       expect(dataCall[1]).toEqual(expect.arrayContaining(countCall[1]));
       expect(dataCall[1].length).toBe(countCall[1].length + 2);
     });
@@ -205,8 +231,8 @@ describe('ResultsOverviewService', () => {
 
       const [dataCall] = mockQuery.mock.calls;
       const dataParams: number[] = dataCall[1];
-      expect(dataParams.at(-2)).toBe(20); // LIMIT
-      expect(dataParams.at(-1)).toBe(40); // OFFSET = (3-1)*20
+      expect(dataParams.at(-2)).toBe(20);
+      expect(dataParams.at(-1)).toBe(40);
     });
 
     it('should return empty data array and total 0 when no rows found', async () => {

--- a/clarisa-back/src/integration/reporting/services/results-overview.service.ts
+++ b/clarisa-back/src/integration/reporting/services/results-overview.service.ts
@@ -7,6 +7,8 @@ import {
   ResultsOverviewPaginatedDto,
 } from '../dto/results-overview-response.dto';
 
+const VIEW = 'vw_results_innovations_overview';
+
 @Injectable()
 export class ResultsOverviewService {
   private readonly logger = new Logger(ResultsOverviewService.name);
@@ -22,6 +24,7 @@ export class ResultsOverviewService {
     const {
       version_id,
       status_id,
+      result_type_id,
       initiative_id,
       center_code,
       search,
@@ -43,20 +46,35 @@ export class ResultsOverviewService {
       params.push(...status_id);
     }
 
+    if (result_type_id?.length) {
+      const placeholders = result_type_id.map(() => '?').join(', ');
+      conditions.push(`vro.result_type_id IN (${placeholders})`);
+      params.push(...result_type_id);
+    }
+
     if (initiative_id != null) {
-      conditions.push(`(
-        vro.lead_initiative_program_id = ?
-        OR FIND_IN_SET(?, REPLACE(vro.contributing_initiative_program_ids, ';', ','))
+      // The view does not expose contributing IDs as a column, so we filter
+      // directly against the source table to cover both lead and contributing.
+      conditions.push(`EXISTS (
+        SELECT 1
+        FROM   results_by_inititiative rbi2
+        WHERE  rbi2.result_id      = vro.result_id
+          AND  rbi2.inititiative_id = ?
+          AND  rbi2.is_active       = 1
       )`);
-      params.push(initiative_id, String(initiative_id));
+      params.push(initiative_id);
     }
 
     if (center_code) {
-      conditions.push(`(
-        vro.lead_center_code = ?
-        OR FIND_IN_SET(?, REPLACE(vro.contributing_center_codes, ';', ','))
+      // Same pattern — query source table directly for lead + contributing.
+      conditions.push(`EXISTS (
+        SELECT 1
+        FROM   results_center rc2
+        WHERE  rc2.result_id  = vro.result_id
+          AND  rc2.center_id  = ?
+          AND  rc2.is_active  = 1
       )`);
-      params.push(center_code, center_code);
+      params.push(center_code);
     }
 
     if (search?.trim()) {
@@ -75,7 +93,7 @@ export class ResultsOverviewService {
 
     const dataQuery = `
       SELECT *
-      FROM   vw_results_overview vro
+      FROM   ${VIEW} vro
       ${whereClause}
       ORDER  BY vro.result_code ASC
       LIMIT  ? OFFSET ?
@@ -83,12 +101,12 @@ export class ResultsOverviewService {
 
     const countQuery = `
       SELECT COUNT(*) AS total
-      FROM   vw_results_overview vro
+      FROM   ${VIEW} vro
       ${whereClause}
     `;
 
     this.logger.log(
-      `Fetching results overview — page ${page}, limit ${limit}, filters: ${JSON.stringify({ version_id, status_id, initiative_id, center_code, search })}`,
+      `Fetching innovations overview — page ${page}, limit ${limit}, filters: ${JSON.stringify({ version_id, status_id, result_type_id, initiative_id, center_code, search })}`,
     );
 
     const [data, countResult] = await Promise.all([
@@ -104,7 +122,9 @@ export class ResultsOverviewService {
 
     const total = Number(countResult[0].total);
 
-    this.logger.log(`Results overview returned ${data.length} / ${total} rows`);
+    this.logger.log(
+      `Innovations overview returned ${data.length} / ${total} rows`,
+    );
 
     return {
       data,

--- a/clarisa-back/src/integration/reporting/services/results-overview.service.ts
+++ b/clarisa-back/src/integration/reporting/services/results-overview.service.ts
@@ -1,0 +1,119 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { ResultsOverviewQueryDto } from '../dto/results-overview-query.dto';
+import {
+  ResultsOverviewItemDto,
+  ResultsOverviewPaginatedDto,
+} from '../dto/results-overview-response.dto';
+
+@Injectable()
+export class ResultsOverviewService {
+  private readonly logger = new Logger(ResultsOverviewService.name);
+
+  constructor(
+    @InjectDataSource('reporting')
+    private readonly reportingDataSource: DataSource,
+  ) {}
+
+  async getResultsOverview(
+    query: ResultsOverviewQueryDto,
+  ): Promise<ResultsOverviewPaginatedDto> {
+    const {
+      version_id,
+      status_id,
+      initiative_id,
+      center_code,
+      search,
+      page = 1,
+      limit = 25,
+    } = query;
+
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (version_id != null) {
+      conditions.push('vro.version_id = ?');
+      params.push(version_id);
+    }
+
+    if (status_id?.length) {
+      const placeholders = status_id.map(() => '?').join(', ');
+      conditions.push(`vro.status_id IN (${placeholders})`);
+      params.push(...status_id);
+    }
+
+    if (initiative_id != null) {
+      conditions.push(`(
+        vro.lead_initiative_program_id = ?
+        OR FIND_IN_SET(?, REPLACE(vro.contributing_initiative_program_ids, ';', ','))
+      )`);
+      params.push(initiative_id, String(initiative_id));
+    }
+
+    if (center_code) {
+      conditions.push(`(
+        vro.lead_center_code = ?
+        OR FIND_IN_SET(?, REPLACE(vro.contributing_center_codes, ';', ','))
+      )`);
+      params.push(center_code, center_code);
+    }
+
+    if (search?.trim()) {
+      conditions.push(
+        '(vro.result_title LIKE ? OR vro.result_description LIKE ?)',
+      );
+      const term = `%${search.trim()}%`;
+      params.push(term, term);
+    }
+
+    const whereClause = conditions.length
+      ? `WHERE ${conditions.join(' AND ')}`
+      : '';
+
+    const offset = (page - 1) * limit;
+
+    const dataQuery = `
+      SELECT *
+      FROM   vw_results_overview vro
+      ${whereClause}
+      ORDER  BY vro.result_code ASC
+      LIMIT  ? OFFSET ?
+    `;
+
+    const countQuery = `
+      SELECT COUNT(*) AS total
+      FROM   vw_results_overview vro
+      ${whereClause}
+    `;
+
+    this.logger.log(
+      `Fetching results overview — page ${page}, limit ${limit}, filters: ${JSON.stringify({ version_id, status_id, initiative_id, center_code, search })}`,
+    );
+
+    const [data, countResult] = await Promise.all([
+      this.reportingDataSource.query(dataQuery, [
+        ...params,
+        limit,
+        offset,
+      ]) as Promise<ResultsOverviewItemDto[]>,
+      this.reportingDataSource.query(countQuery, params) as Promise<
+        { total: string }[]
+      >,
+    ]);
+
+    const total = Number(countResult[0].total);
+
+    this.logger.log(`Results overview returned ${data.length} / ${total} rows`);
+
+    return {
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        total_pages: Math.ceil(total / limit),
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /integration/innovation/results-overview` backed by `vw_results_innovations_overview`, returning paginated PRMS innovation results (types 2, 7, 10) with science programs and centers
- Introduces `InnovationModule` mounted at `/integration/innovation` (separate from the existing `/integration/taat` path)
- Adds robust filtering by phase (`version_id`), status, result type, science program (lead + contributing), center (lead + contributing), and full-text search with page/limit pagination (max 100)

## What changed

- `src/integration/innovation/innovation.module.ts` — new module wiring the endpoint
- `src/integration/integration.module.ts` + `integration.routes.ts` — registers `InnovationModule` at `/integration/innovation`
- `src/integration/reporting/services/results-overview.service.ts` — queries `vw_results_innovations_overview` with dynamic WHERE + EXISTS subqueries for initiative/center filters
- `src/integration/reporting/results-overview.controller.ts` — `GET /results-overview` with `ValidationPipe`
- `src/integration/reporting/dto/results-overview-query.dto.ts` — query params DTO
- `src/integration/reporting/dto/results-overview-response.dto.ts` — response shape DTO
- `src/integration/reporting/reporting.module.ts` — scoped back to TAAT-only providers
- `docs/results-overview-endpoint.md` — endpoint reference documentation
- 23 unit tests, lint clean, build passing

## Test plan

- [ ] `GET /integration/innovation/results-overview` returns paginated data
- [ ] `?version_id=` filters by phase
- [ ] `?status_id=2&status_id=3` returns results matching either status
- [ ] `?result_type_id=7` returns only Innovation Development
- [ ] `?initiative_id=` matches lead and contributing programs
- [ ] `?center_code=CIP` matches lead and contributing centers
- [ ] `?search=maize` does partial match on title/description
- [ ] `?page=2&limit=10` returns correct slice and pagination metadata
- [ ] Existing `/integration/taat/innovation/*` endpoints unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)